### PR TITLE
ci: run tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
           cmake-path: /usr/bin/
           cmake-init-env: CXXFLAGS=-Werror
         - os: macOS-latest
+          cmake-args: -DCMAKE_TESTING_ENABLED=ON
           cmake-init-env: CXXFLAGS=-Werror
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,67 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+  merge_group:
+
+jobs:
+  build-cmake:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest, ubuntu-20.04]
+        include:
+        - os: ubuntu-latest
+          cmake-args: -DCMAKE_TESTING_ENABLED=ON
+          cmake-init-env: CXXFLAGS=-Werror
+        - os: ubuntu-20.04
+          cmake-args: -DCMAKE_TESTING_ENABLED=ON
+          cmake-path: /usr/bin/
+          cmake-init-env: CXXFLAGS=-Werror
+        - os: macOS-latest
+          cmake-init-env: CXXFLAGS=-Werror
+        - os: windows-latest
+          cmake-args: -A x64 -DCMAKE_TESTING_ENABLED=ON
+          cmake-init-env: CXXFLAGS=/WX LDFLAGS=/WX
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Prepare Linux
+      if: contains(matrix.os, 'ubuntu')
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y pkg-config cmake cmake build-essential
+
+    - name: Prepare macOS
+      if: contains(matrix.os, 'macOS')
+      run: |
+        brew update || true
+        brew install pkg-config cmake || true
+        sudo rm -rf /Library/Developer/CommandLineTools
+
+    - name: Test in debug mode
+      run: |
+        mkdir debug
+        cd debug
+        ${{ matrix.cmake-path }}cmake -E env ${{ matrix.cmake-init-env }} ${{ matrix.cmake-path }}cmake ${{ matrix.cmake-args }} -DCMAKE_BUILD_TYPE=Debug -Werror=dev ..
+        ${{ matrix.cmake-path }}cmake --build . --config Debug --target run_tests ${{ matrix.build-args }}
+
+    - name: Test in release mode
+      run: |
+        mkdir release
+        cd release
+        ${{ matrix.cmake-path }}cmake -E env ${{ matrix.cmake-init-env }} ${{ matrix.cmake-path }}cmake ${{ matrix.cmake-args }} -DCMAKE_BUILD_TYPE=Release -Werror=dev ..
+        ${{ matrix.cmake-path }}cmake --build . --config Release --target run_tests ${{ matrix.build-args }}
+
+    - name: Test with bloat off
+      run: |
+        mkdir bloat
+        cd bloat
+        ${{ matrix.cmake-path }}cmake -E env ${{ matrix.cmake-init-env }} ${{ matrix.cmake-path }}cmake ${{ matrix.cmake-args }} -DCMAKE_BUILD_TYPE=Debug -Werror=dev -DBLOAT=OFF ..
+        ${{ matrix.cmake-path }}cmake --build . --config Debug --target run_tests ${{ matrix.build-args }}
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,12 @@ on:
   merge_group:
 
 jobs:
-  build-cmake:
+  unit-tests:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest, ubuntu-20.04]
+        os: [ubuntu-latest, macOS-latest, ubuntu-20.04]
         include:
         - os: ubuntu-latest
           cmake-args: -DCMAKE_TESTING_ENABLED=ON
@@ -22,9 +22,6 @@ jobs:
           cmake-init-env: CXXFLAGS=-Werror
         - os: macOS-latest
           cmake-init-env: CXXFLAGS=-Werror
-        - os: windows-latest
-          cmake-args: -A x64 -DCMAKE_TESTING_ENABLED=ON
-          cmake-init-env: CXXFLAGS=/WX LDFLAGS=/WX
 
     steps:
     - uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if(CMAKE_TESTING_ENABLED)
     include(FetchContent)
         FetchContent_Declare(
         googletest
-        URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+        URL https://github.com/google/googletest/archive/35d0c365609296fa4730d62057c487e3cfa030ff.zip
     )
 
     # For Windows: Prevent overriding the parent project's compiler/linker settings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if(CMAKE_TESTING_ENABLED)
     include(FetchContent)
         FetchContent_Declare(
         googletest
-        URL https://github.com/google/googletest/archive/35d0c365609296fa4730d62057c487e3cfa030ff.zip
+        URL https://github.com/google/googletest/archive/3d73dee972d0db344bda9b659836612aba6a3564.zip
     )
 
     # For Windows: Prevent overriding the parent project's compiler/linker settings


### PR DESCRIPTION
It could be integrated into the build flow to be a bit faster. But I think the project is small enough to waste some CI ressources. Then the overview is nicer and you know instantly if it is the build failing or only the test failing.

Closed #22