### PR TITLE
ci: enforce lowercase hex

### DIFF
--- a/scripts/fix_style.sh
+++ b/scripts/fix_style.sh
@@ -6,3 +6,9 @@ while read -r src_file
 do
 	clang-format -Werror "$clang_arg" "$src_file" || exit 1
 done < <(find ./src \( -name '*.h' -o -name '*.c' -o -name '*.cc' \))
+
+if grep -rnEo '0x[A-Z0-9]+' src/ | grep -E '0x.*[A-Z]'
+then
+	printf 'Error: detected upper case hex values ^ please use lowercase\n'
+	exit 1
+fi

--- a/src/huffman.c
+++ b/src/huffman.c
@@ -88,7 +88,7 @@ static void construct_tree(const uint32_t *frequencies) {
 
 	// add the symbols
 	for(int32_t i = 0; i < HUFFMAN_MAX_SYMBOLS; i++) {
-		nodes[i].num_bits = 0xFFFFFFFF;
+		nodes[i].num_bits = 0xffffffff;
 		nodes[i].symbol = i;
 		nodes[i].leafs[0] = 0xffff;
 		nodes[i].leafs[1] = 0xffff;


### PR DESCRIPTION
I searched 10 seconds if clang tidy can do it. Could not find it xd