### PR TITLE
feat: store packet header in control packet struct

### DIFF
--- a/include/ddnet_protocol/control_packet.h
+++ b/include/ddnet_protocol/control_packet.h
@@ -13,9 +13,10 @@ typedef enum {
 
 typedef struct {
 	PacketKind _;
+	PacketHeader header;
 	ControlMessageKind kind;
 	Token token;
 	char *reason; // Can be set if msg_kind == CTRL_MSG_CLOSE
 } PacketControl;
 
-PacketControl *decode_control(uint8_t *buf, size_t len, Error *err);
+PacketControl *decode_control(uint8_t *buf, size_t len, PacketHeader header, Error *err);

--- a/src/control_packet.c
+++ b/src/control_packet.c
@@ -1,6 +1,7 @@
 #include "control_packet.h"
+#include "packet.h"
 
-PacketControl *decode_control(uint8_t *buf, size_t len, Error *err) {
+PacketControl *decode_control(uint8_t *buf, size_t len, PacketHeader header, Error *err) {
 	ControlMessageKind kind = buf[0];
 	char *reason = NULL;
 
@@ -47,6 +48,7 @@ PacketControl *decode_control(uint8_t *buf, size_t len, Error *err) {
 	PacketControl *packet = malloc(sizeof(PacketControl));
 
 	packet->_ = PACKET_CONTROL;
+	packet->header = header;
 	packet->kind = kind;
 	packet->reason = reason;
 	packet->token = read_token(&buf[1]);

--- a/src/packet.c
+++ b/src/packet.c
@@ -18,10 +18,10 @@ PacketKind *decode(uint8_t *buf, size_t len, Error *err) {
 		return NULL;
 	}
 
-	uint8_t flags = buf[0] >> 2;
+	PacketHeader header = decode_packet_header(buf);
 
-	if(flags & PACKET_FLAG_CONTROL) {
-		return (PacketKind *)decode_control(&buf[3], len - 3, err);
+	if(header.flags & PACKET_FLAG_CONTROL) {
+		return (PacketKind *)decode_control(&buf[3], len - 3, header, err);
 	} else if(err) {
 		*err = ERR_INVALID_PACKET;
 	}

--- a/test/control_packet.cc
+++ b/test/control_packet.cc
@@ -13,6 +13,9 @@ TEST(ControlPacket, Keepalive) {
 	EXPECT_TRUE(packet != nullptr);
 	EXPECT_EQ(err, Error::ERR_NONE);
 	EXPECT_EQ(packet->_, PacketKind::PACKET_CONTROL);
+	EXPECT_EQ(packet->header.flags, PacketFlag::PACKET_FLAG_CONTROL);
+	EXPECT_EQ(packet->header.num_chunks, 0);
+	EXPECT_EQ(packet->header.ack, 0);
 	EXPECT_EQ((packet)->kind, ControlMessageKind::CTRL_MSG_KEEPALIVE);
 	EXPECT_TRUE(packet->reason == nullptr);
 	EXPECT_EQ(packet->token, 0x4ec73b04);


### PR DESCRIPTION
This allows the user to call `decode()` and receive the full information about the packet. Including its header.