### PR TITLE
refactor: rename header sizes

### DIFF
--- a/docs/packet.md
+++ b/docs/packet.md
@@ -1,19 +1,19 @@
-# PACKET_MIN_HEADER_SIZE
+# PACKET_HEADER_SIZE
 
 ## Syntax
 
 ```C
-#define PACKET_MIN_HEADER_SIZE 3
+#define PACKET_HEADER_SIZE 3
 ```
 
 minimum size in bytes required for a valid packet header
 
-# PACKET_MAX_HEADER_SIZE
+# MAX_PACKET_SIZE
 
 ## Syntax
 
 ```C
-#define PACKET_MAX_HEADER_SIZE 1400
+#define MAX_PACKET_SIZE 1400
 ```
 
 maximum amount of total packet size

--- a/include/ddnet_protocol/packet.h
+++ b/include/ddnet_protocol/packet.h
@@ -5,10 +5,10 @@
 #include "token.h"
 
 // minimum size in bytes required for a valid packet header
-#define PACKET_MIN_HEADER_SIZE 3
+#define PACKET_HEADER_SIZE 3
 
 // maximum amount of total packet size
-#define PACKET_MAX_HEADER_SIZE 1400
+#define MAX_PACKET_SIZE 1400
 
 // internal enum for packet types
 // not sent over the network

--- a/src/packet.c
+++ b/src/packet.c
@@ -11,7 +11,7 @@ PacketHeader decode_packet_header(uint8_t *buf) {
 }
 
 PacketKind *decode(uint8_t *buf, size_t len, Error *err) {
-	if(len < PACKET_MIN_HEADER_SIZE || len > PACKET_MAX_HEADER_SIZE) {
+	if(len < PACKET_HEADER_SIZE || len > MAX_PACKET_SIZE) {
 		if(err) {
 			*err = ERR_INVALID_PACKET;
 		}


### PR DESCRIPTION
The old one sounded like a packet header could be longer than 3 bytes.