### PR TITLE
refactor: replace magic cast with `Packet` union

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ build
 
 a.out
 *.o
+*.o.d
+
+# ninja build
 
 .ninja_deps
 .ninja_log
@@ -23,3 +26,24 @@ cmake_install.cmake
 cmake_uninstall.cmake
 compile_commands.json
 libddnet_protocol.a
+
+# make build
+
+CMakeDirectoryInformation.cmake
+CMakeRuleHashes.txt
+Makefile.cmake
+Makefile
+Makefile2
+DependInfo.cmake
+build.make
+cmake_clean.cmake
+cmake_clean_target.cmake
+depend.make
+flags.make
+link.txt
+cmake_clean.cmake
+compiler_depend.make
+compiler_depend.ts
+progress.marks
+progress.make
+compiler_depend.internal

--- a/docs/chunk.md
+++ b/docs/chunk.md
@@ -92,7 +92,7 @@ typedef struct {
 	ChunkKind kind;
 	ChunkHeader header;
 	union {
-		MsgNull *null;
+		void *unused;
 		MsgRconCmd *rcon_cmd;
 	} msg;
 } Chunk;

--- a/docs/chunk.md
+++ b/docs/chunk.md
@@ -92,7 +92,8 @@ typedef struct {
 	ChunkKind kind;
 	ChunkHeader header;
 	union {
-		MsgRconCmd rcon_cmd;
+		MsgNull *null;
+		MsgRconCmd *rcon_cmd;
 	} msg;
 } Chunk;
 ```

--- a/docs/packet.md
+++ b/docs/packet.md
@@ -192,5 +192,15 @@ this determins the type of packet.
 
 It returns `NULL` on error. Check the `err` value for more details.
 Or a pointer to newly allocated memory that holds the parsed packet struct.
-It is your responsiblity to free that pointer!
+It is your responsiblity to free it using `free_packet()`
+
+# free_packet
+
+## Syntax
+
+```C
+Error free_packet(Packet *packet);
+```
+
+Frees a packet struct and all of its fields
 

--- a/docs/packet.md
+++ b/docs/packet.md
@@ -147,20 +147,6 @@ Control packet
 
 allow the user to define their own max? To reduce memory usage.
 
-# PacketNormal
-
-## Syntax
-
-```C
-typedef struct {
-	Chunk chunks[MAX_CHUNKS];
-} PacketNormal;
-```
-
-Struct holding the packet payload of a regular packet.
-It contains chunks which hold all the gameplay relevant
-net messages.
-
 # Packet
 
 ## Syntax
@@ -171,7 +157,7 @@ typedef struct {
 	PacketHeader header;
 	union {
 		PacketControl *control;
-		PacketNormal *normal;
+		Chunk chunks[MAX_CHUNKS];
 	};
 } Packet;
 ```

--- a/docs/packet.md
+++ b/docs/packet.md
@@ -153,7 +153,7 @@ allow the user to define their own max? To reduce memory usage.
 
 ```C
 typedef struct {
-	PacketKind _;
+	PacketKind kind;
 	PacketHeader header;
 	union {
 		PacketControl *control;

--- a/docs/packet.md
+++ b/docs/packet.md
@@ -108,6 +108,76 @@ header.num_chunks = 0; // control packets have no chunks
 header.token = TOKEN_MAGIC;
 ```
 
+# ControlMessageKind
+
+## Syntax
+
+```C
+typedef enum {
+	CTRL_MSG_KEEPALIVE,
+	CTRL_MSG_CONNECT,
+	CTRL_MSG_CONNECTACCEPT,
+	CTRL_MSG_ACCEPT,
+	CTRL_MSG_CLOSE,
+} ControlMessageKind;
+```
+
+Type of control packet
+
+# PacketControl
+
+## Syntax
+
+```C
+typedef struct {
+	ControlMessageKind kind;
+	char *reason; // Can be set if msg_kind == CTRL_MSG_CLOSE
+} PacketControl;
+```
+
+Control packet
+
+# MAX_CHUNKS
+
+## Syntax
+
+```C
+#define MAX_CHUNKS 512
+```
+
+allow the user to define their own max? To reduce memory usage.
+
+# PacketNormal
+
+## Syntax
+
+```C
+typedef struct {
+	Chunk chunks[MAX_CHUNKS];
+} PacketNormal;
+```
+
+Struct holding the packet payload of a regular packet.
+It contains chunks which hold all the gameplay relevant
+net messages.
+
+# Packet
+
+## Syntax
+
+```C
+typedef struct {
+	PacketKind _;
+	PacketHeader header;
+	union {
+		PacketControl *control;
+		PacketNormal *normal;
+	};
+} Packet;
+```
+
+Holds information about on full ddnet packet
+
 # decode_packet_header
 
 ## Syntax
@@ -128,7 +198,7 @@ https://github.com/MilkeeyCat/ddnet_protocol/issues/54
 ## Syntax
 
 ```C
-PacketKind *decode(uint8_t *buf, size_t len, Error *err);
+Packet *decode(uint8_t *buf, size_t len, Error *err);
 ```
 
 Given a pointer to the beginning of a udp payload

--- a/include/ddnet_protocol/chunk.h
+++ b/include/ddnet_protocol/chunk.h
@@ -67,6 +67,7 @@ typedef struct {
 	ChunkKind kind;
 	ChunkHeader header;
 	union {
-		MsgRconCmd rcon_cmd;
+		MsgNull *null;
+		MsgRconCmd *rcon_cmd;
 	} msg;
 } Chunk;

--- a/include/ddnet_protocol/chunk.h
+++ b/include/ddnet_protocol/chunk.h
@@ -67,7 +67,7 @@ typedef struct {
 	ChunkKind kind;
 	ChunkHeader header;
 	union {
-		MsgNull *null;
+		void *unused;
 		MsgRconCmd *rcon_cmd;
 	} msg;
 } Chunk;

--- a/include/ddnet_protocol/common.h
+++ b/include/ddnet_protocol/common.h
@@ -1,12 +1,16 @@
 #pragma once
 
 #ifdef BLOAT
+#include <assert.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #else
+#ifndef assert
+#define assert
+#endif
 typedef unsigned char uint8_t;
 typedef unsigned short int uint16_t;
 typedef int int32_t;

--- a/include/ddnet_protocol/fetch_chunks.h
+++ b/include/ddnet_protocol/fetch_chunks.h
@@ -8,4 +8,5 @@
 
 // Given a buffer containing the packet payload without packet header.
 // It will extract all system and game messages.
-PacketNormal *decode_normal(uint8_t *buf, size_t len, PacketHeader *header, Error *err);
+// And store them in the given packet struct.
+Error fetch_chunks(uint8_t *buf, size_t len, Packet *packet);

--- a/include/ddnet_protocol/msg_system.h
+++ b/include/ddnet_protocol/msg_system.h
@@ -2,15 +2,6 @@
 
 #include "common.h"
 
-// Not a real net message.
-// Also its field is only there to please the compiler.
-// This is a generic message that represents invalid messages.
-// Or all messages.
-typedef struct {
-	// This value is never set. Do not read it.
-	uint8_t _;
-} MsgNull;
-
 // Sent by the client.
 // The `command` will be executed in the server console.
 typedef struct {

--- a/include/ddnet_protocol/msg_system.h
+++ b/include/ddnet_protocol/msg_system.h
@@ -1,5 +1,18 @@
 #pragma once
 
+#include "common.h"
+
+// Not a real net message.
+// Also its field is only there to please the compiler.
+// This is a generic message that represents invalid messages.
+// Or all messages.
+typedef struct {
+	// This value is never set. Do not read it.
+	uint8_t _;
+} MsgNull;
+
+// Sent by the client.
+// The `command` will be executed in the server console.
 typedef struct {
 	const char *command;
 } MsgRconCmd;

--- a/include/ddnet_protocol/packet.h
+++ b/include/ddnet_protocol/packet.h
@@ -108,20 +108,13 @@ typedef struct {
 #define MAX_CHUNKS 512
 #endif
 
-// Struct holding the packet payload of a regular packet.
-// It contains chunks which hold all the gameplay relevant
-// net messages.
-typedef struct {
-	Chunk chunks[MAX_CHUNKS];
-} PacketNormal;
-
 // Holds information about on full ddnet packet
 typedef struct {
 	PacketKind _;
 	PacketHeader header;
 	union {
 		PacketControl *control;
-		PacketNormal *normal;
+		Chunk chunks[MAX_CHUNKS];
 	};
 } Packet;
 

--- a/include/ddnet_protocol/packet.h
+++ b/include/ddnet_protocol/packet.h
@@ -110,7 +110,7 @@ typedef struct {
 
 // Holds information about on full ddnet packet
 typedef struct {
-	PacketKind _;
+	PacketKind kind;
 	PacketHeader header;
 	union {
 		PacketControl *control;

--- a/include/ddnet_protocol/packet.h
+++ b/include/ddnet_protocol/packet.h
@@ -131,5 +131,8 @@ PacketHeader decode_packet_header(uint8_t *buf);
 //
 // It returns `NULL` on error. Check the `err` value for more details.
 // Or a pointer to newly allocated memory that holds the parsed packet struct.
-// It is your responsiblity to free that pointer!
+// It is your responsiblity to free it using `free_packet()`
 Packet *decode(uint8_t *buf, size_t len, Error *err);
+
+// Frees a packet struct and all of its fields
+Error free_packet(Packet *packet);

--- a/include/ddnet_protocol/packet_control.h
+++ b/include/ddnet_protocol/packet_control.h
@@ -3,21 +3,6 @@
 #include "packet.h"
 #include "token.h"
 
-typedef enum {
-	CTRL_MSG_KEEPALIVE,
-	CTRL_MSG_CONNECT,
-	CTRL_MSG_CONNECTACCEPT,
-	CTRL_MSG_ACCEPT,
-	CTRL_MSG_CLOSE,
-} ControlMessageKind;
-
-typedef struct {
-	PacketKind _;
-	PacketHeader header;
-	ControlMessageKind kind;
-	char *reason; // Can be set if msg_kind == CTRL_MSG_CLOSE
-} PacketControl;
-
 // Given a buffer containing the packet payload without packet header.
 // It will extract one control message.
-PacketControl *decode_control(uint8_t *buf, size_t len, PacketHeader header, Error *err);
+PacketControl *decode_control(uint8_t *buf, size_t len, PacketHeader *header, Error *err);

--- a/include/ddnet_protocol/packet_normal.h
+++ b/include/ddnet_protocol/packet_normal.h
@@ -6,21 +6,6 @@
 #include "packet.h"
 #include "token.h"
 
-// allow the user to define their own max? To reduce memory usage.
-#ifndef MAX_CHUNKS
-#define MAX_CHUNKS 512
-#endif
-
-// Struct holding the packet payload of a regular packet.
-// It contains chunks which hold all the gameplay relevant
-// net messages.
-typedef struct {
-	PacketKind _;
-	PacketHeader header;
-	Token token;
-	Chunk chunks[MAX_CHUNKS];
-} PacketNormal;
-
 // Given a buffer containing the packet payload without packet header.
 // It will extract all system and game messages.
-PacketNormal *decode_normal(uint8_t *buf, size_t len, PacketHeader header, Error *err);
+PacketNormal *decode_normal(uint8_t *buf, size_t len, PacketHeader *header, Error *err);

--- a/scripts/docs.rb
+++ b/scripts/docs.rb
@@ -40,7 +40,7 @@ class BaseDoc
   end
 
   def self.is_func?(line)
-    !line.match(/(const )?(u?int(32|8)_t|size_t|bool|void|char|Unpacker|Token|PacketHeader|PacketKind|ChunkHeader) \*?\w+\(/).nil?
+    !line.match(/(const )?(u?int(32|8)_t|size_t|bool|void|char|Unpacker|Token|Packet|PacketHeader|PacketKind|ChunkHeader) \*?\w+\(/).nil?
   end
 
   def self.is_typedef?(line)

--- a/scripts/docs.rb
+++ b/scripts/docs.rb
@@ -40,7 +40,7 @@ class BaseDoc
   end
 
   def self.is_func?(line)
-    !line.match(/(const )?(u?int(32|8)_t|size_t|bool|void|char|Unpacker|Token|Packet|PacketHeader|PacketKind|ChunkHeader) \*?\w+\(/).nil?
+    !line.match(/(const )?(u?int(32|8)_t|size_t|bool|void|char|Error|Unpacker|Token|Packet|PacketHeader|PacketKind|ChunkHeader) \*?\w+\(/).nil?
   end
 
   def self.is_typedef?(line)

--- a/src/message.c
+++ b/src/message.c
@@ -20,7 +20,9 @@ static Error decode_game_message(Chunk *chunk, MessageId msg_id, Unpacker *unpac
 static Error decode_system_message(Chunk *chunk, MessageId msg_id, Unpacker *unpacker) {
 	switch(msg_id) {
 	case MSG_RCON_CMD:
-		chunk->msg.rcon_cmd.command = unpacker_get_string(unpacker);
+		assert(chunk->msg.rcon_cmd == NULL);
+		chunk->msg.rcon_cmd = malloc(sizeof(MsgRconCmd));
+		chunk->msg.rcon_cmd->command = unpacker_get_string(unpacker);
 		chunk->kind = CHUNK_KIND_RCON_CMD;
 		break;
 	default:

--- a/src/packet.c
+++ b/src/packet.c
@@ -25,10 +25,10 @@ Packet *decode(uint8_t *buf, size_t len, Error *err) {
 	packet->header = decode_packet_header(buf);
 
 	if(packet->header.flags & PACKET_FLAG_CONTROL) {
-		packet->_ = PACKET_CONTROL;
+		packet->kind = PACKET_CONTROL;
 		packet->control = decode_control(&buf[3], len - 3, &packet->header, err);
 	} else {
-		packet->_ = PACKET_NORMAL;
+		packet->kind = PACKET_NORMAL;
 		Error chunk_error = fetch_chunks(&buf[3], len - 3, packet);
 		if(chunk_error != ERR_NONE) {
 			if(err) {
@@ -43,9 +43,9 @@ Packet *decode(uint8_t *buf, size_t len, Error *err) {
 }
 
 Error free_packet(Packet *packet) {
-	if(packet->_ == PACKET_NORMAL) {
+	if(packet->kind == PACKET_NORMAL) {
 		for(size_t i = 0; i < MAX_CHUNKS; i++) {
-			free(packet->chunks[i].msg.null);
+			free(packet->chunks[i].msg.unused);
 		}
 	}
 	free(packet);

--- a/src/packet.c
+++ b/src/packet.c
@@ -21,6 +21,7 @@ Packet *decode(uint8_t *buf, size_t len, Error *err) {
 	}
 
 	Packet *packet = malloc(sizeof(Packet));
+	memset(packet, 0, sizeof(*packet));
 	packet->header = decode_packet_header(buf);
 
 	if(packet->header.flags & PACKET_FLAG_CONTROL) {
@@ -39,4 +40,14 @@ Packet *decode(uint8_t *buf, size_t len, Error *err) {
 	}
 
 	return packet;
+}
+
+Error free_packet(Packet *packet) {
+	if(packet->_ == PACKET_NORMAL) {
+		for(size_t i = 0; i < MAX_CHUNKS; i++) {
+			free(packet->chunks[i].msg.null);
+		}
+	}
+	free(packet);
+	return ERR_NONE;
 }

--- a/src/packet.c
+++ b/src/packet.c
@@ -34,7 +34,7 @@ Packet *decode(uint8_t *buf, size_t len, Error *err) {
 			if(err) {
 				*err = chunk_error;
 			}
-			free(packet);
+			free_packet(packet);
 			return NULL;
 		}
 	}

--- a/src/packet_control.c
+++ b/src/packet_control.c
@@ -1,7 +1,8 @@
-#include "packet_control.h"
 #include "packet.h"
 
-PacketControl *decode_control(uint8_t *buf, size_t len, PacketHeader header, Error *err) {
+#include "packet_control.h"
+
+PacketControl *decode_control(uint8_t *buf, size_t len, PacketHeader *header, Error *err) {
 	ControlMessageKind kind = buf[0];
 	char *reason = NULL;
 
@@ -43,9 +44,7 @@ PacketControl *decode_control(uint8_t *buf, size_t len, PacketHeader header, Err
 
 	PacketControl *packet = malloc(sizeof(PacketControl));
 
-	packet->_ = PACKET_CONTROL;
-	packet->header = header;
-	packet->header.token = read_token(&buf[1]);
+	header->token = read_token(&buf[1]);
 	packet->kind = kind;
 	packet->reason = reason;
 

--- a/src/packet_normal.c
+++ b/src/packet_normal.c
@@ -3,16 +3,14 @@
 #include "message.h"
 #include "packet.h"
 
-PacketNormal *decode_normal(uint8_t *buf, size_t len, PacketHeader header, Error *err) {
+PacketNormal *decode_normal(uint8_t *buf, size_t len, PacketHeader *header, Error *err) {
 	PacketNormal *packet = malloc(sizeof(PacketNormal));
-	packet->_ = PACKET_NORMAL;
-	packet->header = header;
 
 	uint8_t *end = buf + len;
 	uint8_t num_chunks = 0;
 
 	while(true) {
-		if(num_chunks == header.num_chunks) {
+		if(num_chunks == header->num_chunks) {
 			break;
 		}
 
@@ -52,7 +50,7 @@ PacketNormal *decode_normal(uint8_t *buf, size_t len, PacketHeader header, Error
 		buf += chunk_header.size;
 	}
 
-	if(num_chunks < header.num_chunks) {
+	if(num_chunks < header->num_chunks) {
 		*err = ERR_END_OF_BUFFER;
 		free(packet);
 		return NULL;
@@ -79,6 +77,6 @@ PacketNormal *decode_normal(uint8_t *buf, size_t len, PacketHeader header, Error
 		return NULL;
 	}
 
-	packet->token = read_token(buf);
+	header->token = read_token(buf);
 	return packet;
 }

--- a/test/packet_control.cc
+++ b/test/packet_control.cc
@@ -12,7 +12,7 @@ TEST(ControlPacket, Keepalive) {
 
 	EXPECT_TRUE(packet != nullptr);
 	EXPECT_EQ(err, Error::ERR_NONE);
-	EXPECT_EQ(packet->_, PacketKind::PACKET_CONTROL);
+	EXPECT_EQ(packet->kind, PacketKind::PACKET_CONTROL);
 	EXPECT_EQ(packet->header.flags, PacketFlag::PACKET_FLAG_CONTROL);
 	EXPECT_EQ(packet->header.num_chunks, 0);
 	EXPECT_EQ(packet->header.ack, 0);
@@ -29,7 +29,7 @@ TEST(ControlPacket, Connect) {
 
 	EXPECT_TRUE(packet != nullptr);
 	EXPECT_EQ(err, Error::ERR_NONE);
-	EXPECT_EQ(packet->_, PacketKind::PACKET_CONTROL);
+	EXPECT_EQ(packet->kind, PacketKind::PACKET_CONTROL);
 	EXPECT_EQ(packet->control->kind, ControlMessageKind::CTRL_MSG_CONNECT);
 	EXPECT_EQ(packet->header.token, 0xffffffff);
 	EXPECT_TRUE(packet->control->reason == nullptr);
@@ -43,7 +43,7 @@ TEST(ControlPacket, ConnectAccept) {
 
 	EXPECT_TRUE(packet != nullptr);
 	EXPECT_EQ(err, Error::ERR_NONE);
-	EXPECT_EQ(packet->_, PacketKind::PACKET_CONTROL);
+	EXPECT_EQ(packet->kind, PacketKind::PACKET_CONTROL);
 	EXPECT_EQ(packet->control->kind, ControlMessageKind::CTRL_MSG_CONNECTACCEPT);
 	EXPECT_EQ(packet->header.token, 0x4ec73b04);
 	EXPECT_TRUE(packet->control->reason == nullptr);
@@ -57,7 +57,7 @@ TEST(ControlPacket, Accept) {
 
 	EXPECT_TRUE(packet != nullptr);
 	EXPECT_EQ(err, Error::ERR_NONE);
-	EXPECT_EQ(packet->_, PacketKind::PACKET_CONTROL);
+	EXPECT_EQ(packet->kind, PacketKind::PACKET_CONTROL);
 	EXPECT_EQ(packet->control->kind, ControlMessageKind::CTRL_MSG_ACCEPT);
 	EXPECT_EQ(packet->header.token, 0x4ec73b04);
 	EXPECT_TRUE(packet->control->reason == nullptr);
@@ -71,7 +71,7 @@ TEST(ControlPacket, Close) {
 
 	EXPECT_TRUE(packet != nullptr);
 	EXPECT_EQ(err, Error::ERR_NONE);
-	EXPECT_EQ(packet->_, PacketKind::PACKET_CONTROL);
+	EXPECT_EQ(packet->kind, PacketKind::PACKET_CONTROL);
 	EXPECT_EQ(packet->control->kind, ControlMessageKind::CTRL_MSG_CLOSE);
 	EXPECT_EQ(packet->header.token, 0x4ec73b04);
 	EXPECT_TRUE(packet->control->reason == nullptr);
@@ -85,7 +85,7 @@ TEST(ControlPacket, CloseWithReason) {
 
 	EXPECT_TRUE(packet != nullptr);
 	EXPECT_EQ(err, Error::ERR_NONE);
-	EXPECT_EQ(packet->_, PacketKind::PACKET_CONTROL);
+	EXPECT_EQ(packet->kind, PacketKind::PACKET_CONTROL);
 	EXPECT_EQ(packet->control->kind, ControlMessageKind::CTRL_MSG_CLOSE);
 	EXPECT_EQ(packet->header.token, 0x4ec73b04);
 	EXPECT_STREQ(packet->control->reason, "too bad");

--- a/test/packet_control.cc
+++ b/test/packet_control.cc
@@ -19,7 +19,7 @@ TEST(ControlPacket, Keepalive) {
 	EXPECT_EQ(packet->header.token, 0x4ec73b04);
 	EXPECT_EQ(packet->control->kind, ControlMessageKind::CTRL_MSG_KEEPALIVE);
 	EXPECT_TRUE(packet->control->reason == nullptr);
-	free(packet);
+	free_packet(packet);
 }
 
 TEST(ControlPacket, Connect) {
@@ -33,7 +33,7 @@ TEST(ControlPacket, Connect) {
 	EXPECT_EQ(packet->control->kind, ControlMessageKind::CTRL_MSG_CONNECT);
 	EXPECT_EQ(packet->header.token, 0xffffffff);
 	EXPECT_TRUE(packet->control->reason == nullptr);
-	free(packet);
+	free_packet(packet);
 }
 
 TEST(ControlPacket, ConnectAccept) {
@@ -47,7 +47,7 @@ TEST(ControlPacket, ConnectAccept) {
 	EXPECT_EQ(packet->control->kind, ControlMessageKind::CTRL_MSG_CONNECTACCEPT);
 	EXPECT_EQ(packet->header.token, 0x4ec73b04);
 	EXPECT_TRUE(packet->control->reason == nullptr);
-	free(packet);
+	free_packet(packet);
 }
 
 TEST(ControlPacket, Accept) {
@@ -61,7 +61,7 @@ TEST(ControlPacket, Accept) {
 	EXPECT_EQ(packet->control->kind, ControlMessageKind::CTRL_MSG_ACCEPT);
 	EXPECT_EQ(packet->header.token, 0x4ec73b04);
 	EXPECT_TRUE(packet->control->reason == nullptr);
-	free(packet);
+	free_packet(packet);
 }
 
 TEST(ControlPacket, Close) {
@@ -75,7 +75,7 @@ TEST(ControlPacket, Close) {
 	EXPECT_EQ(packet->control->kind, ControlMessageKind::CTRL_MSG_CLOSE);
 	EXPECT_EQ(packet->header.token, 0x4ec73b04);
 	EXPECT_TRUE(packet->control->reason == nullptr);
-	free(packet);
+	free_packet(packet);
 }
 
 TEST(ControlPacket, CloseWithReason) {
@@ -89,5 +89,5 @@ TEST(ControlPacket, CloseWithReason) {
 	EXPECT_EQ(packet->control->kind, ControlMessageKind::CTRL_MSG_CLOSE);
 	EXPECT_EQ(packet->header.token, 0x4ec73b04);
 	EXPECT_STREQ(packet->control->reason, "too bad");
-	free(packet);
+	free_packet(packet);
 }

--- a/test/packet_control.cc
+++ b/test/packet_control.cc
@@ -8,7 +8,7 @@ extern "C" {
 TEST(ControlPacket, Keepalive) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x00, 0x4e, 0xc7, 0x3b, 0x04};
 	Error err = Error::ERR_NONE;
-	PacketControl *packet = (PacketControl *)decode(bytes, sizeof(bytes), &err);
+	Packet *packet = decode(bytes, sizeof(bytes), &err);
 
 	EXPECT_TRUE(packet != nullptr);
 	EXPECT_EQ(err, Error::ERR_NONE);
@@ -17,77 +17,77 @@ TEST(ControlPacket, Keepalive) {
 	EXPECT_EQ(packet->header.num_chunks, 0);
 	EXPECT_EQ(packet->header.ack, 0);
 	EXPECT_EQ(packet->header.token, 0x4ec73b04);
-	EXPECT_EQ((packet)->kind, ControlMessageKind::CTRL_MSG_KEEPALIVE);
-	EXPECT_TRUE(packet->reason == nullptr);
+	EXPECT_EQ(packet->control->kind, ControlMessageKind::CTRL_MSG_KEEPALIVE);
+	EXPECT_TRUE(packet->control->reason == nullptr);
 	free(packet);
 }
 
 TEST(ControlPacket, Connect) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x01, 0x54, 0x4b, 0x45, 0x4e, 0xff, 0xff, 0xff, 0xff};
 	Error err = Error::ERR_NONE;
-	PacketControl *packet = (PacketControl *)decode(bytes, sizeof(bytes), &err);
+	Packet *packet = decode(bytes, sizeof(bytes), &err);
 
 	EXPECT_TRUE(packet != nullptr);
 	EXPECT_EQ(err, Error::ERR_NONE);
 	EXPECT_EQ(packet->_, PacketKind::PACKET_CONTROL);
-	EXPECT_EQ((packet)->kind, ControlMessageKind::CTRL_MSG_CONNECT);
+	EXPECT_EQ(packet->control->kind, ControlMessageKind::CTRL_MSG_CONNECT);
 	EXPECT_EQ(packet->header.token, 0xffffffff);
-	EXPECT_TRUE(packet->reason == nullptr);
+	EXPECT_TRUE(packet->control->reason == nullptr);
 	free(packet);
 }
 
 TEST(ControlPacket, ConnectAccept) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x02, 0x54, 0x4b, 0x45, 0x4e, 0x4e, 0xc7, 0x3b, 0x04};
 	Error err = Error::ERR_NONE;
-	PacketControl *packet = (PacketControl *)decode(bytes, sizeof(bytes), &err);
+	Packet *packet = decode(bytes, sizeof(bytes), &err);
 
 	EXPECT_TRUE(packet != nullptr);
 	EXPECT_EQ(err, Error::ERR_NONE);
 	EXPECT_EQ(packet->_, PacketKind::PACKET_CONTROL);
-	EXPECT_EQ((packet)->kind, ControlMessageKind::CTRL_MSG_CONNECTACCEPT);
+	EXPECT_EQ(packet->control->kind, ControlMessageKind::CTRL_MSG_CONNECTACCEPT);
 	EXPECT_EQ(packet->header.token, 0x4ec73b04);
-	EXPECT_TRUE(packet->reason == nullptr);
+	EXPECT_TRUE(packet->control->reason == nullptr);
 	free(packet);
 }
 
 TEST(ControlPacket, Accept) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x03, 0x4e, 0xc7, 0x3b, 0x04};
 	Error err = Error::ERR_NONE;
-	PacketControl *packet = (PacketControl *)decode(bytes, sizeof(bytes), &err);
+	Packet *packet = decode(bytes, sizeof(bytes), &err);
 
 	EXPECT_TRUE(packet != nullptr);
 	EXPECT_EQ(err, Error::ERR_NONE);
 	EXPECT_EQ(packet->_, PacketKind::PACKET_CONTROL);
-	EXPECT_EQ((packet)->kind, ControlMessageKind::CTRL_MSG_ACCEPT);
+	EXPECT_EQ(packet->control->kind, ControlMessageKind::CTRL_MSG_ACCEPT);
 	EXPECT_EQ(packet->header.token, 0x4ec73b04);
-	EXPECT_TRUE(packet->reason == nullptr);
+	EXPECT_TRUE(packet->control->reason == nullptr);
 	free(packet);
 }
 
 TEST(ControlPacket, Close) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x04, 0x4e, 0xc7, 0x3b, 0x04};
 	Error err = Error::ERR_NONE;
-	PacketControl *packet = (PacketControl *)decode(bytes, sizeof(bytes), &err);
+	Packet *packet = decode(bytes, sizeof(bytes), &err);
 
 	EXPECT_TRUE(packet != nullptr);
 	EXPECT_EQ(err, Error::ERR_NONE);
 	EXPECT_EQ(packet->_, PacketKind::PACKET_CONTROL);
-	EXPECT_EQ((packet)->kind, ControlMessageKind::CTRL_MSG_CLOSE);
+	EXPECT_EQ(packet->control->kind, ControlMessageKind::CTRL_MSG_CLOSE);
 	EXPECT_EQ(packet->header.token, 0x4ec73b04);
-	EXPECT_TRUE(packet->reason == nullptr);
+	EXPECT_TRUE(packet->control->reason == nullptr);
 	free(packet);
 }
 
 TEST(ControlPacket, CloseWithReason) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x04, 0x74, 0x6f, 0x6f, 0x20, 0x62, 0x61, 0x64, 0x00, 0x4e, 0xc7, 0x3b, 0x04};
 	Error err = Error::ERR_NONE;
-	PacketControl *packet = (PacketControl *)decode(bytes, sizeof(bytes), &err);
+	Packet *packet = decode(bytes, sizeof(bytes), &err);
 
 	EXPECT_TRUE(packet != nullptr);
 	EXPECT_EQ(err, Error::ERR_NONE);
 	EXPECT_EQ(packet->_, PacketKind::PACKET_CONTROL);
-	EXPECT_EQ((packet)->kind, ControlMessageKind::CTRL_MSG_CLOSE);
+	EXPECT_EQ(packet->control->kind, ControlMessageKind::CTRL_MSG_CLOSE);
 	EXPECT_EQ(packet->header.token, 0x4ec73b04);
-	EXPECT_STREQ(packet->reason, "too bad");
+	EXPECT_STREQ(packet->control->reason, "too bad");
 	free(packet);
 }

--- a/test/packet_normal.cc
+++ b/test/packet_normal.cc
@@ -2,7 +2,6 @@
 
 extern "C" {
 #include <ddnet_protocol/packet.h>
-#include <ddnet_protocol/packet_normal.h>
 }
 
 TEST(NormalPacket, StartInfoAndRconCmd) {
@@ -27,9 +26,9 @@ TEST(NormalPacket, StartInfoAndRconCmd) {
 	EXPECT_EQ(packet->header.ack, 6);
 	EXPECT_EQ(packet->header.token, 0x3de3948d);
 
-	EXPECT_EQ(packet->normal->chunks[0].kind, CHUNK_KIND_CL_STARTINFO);
-	EXPECT_EQ(packet->normal->chunks[1].kind, CHUNK_KIND_RCON_CMD);
-	EXPECT_STREQ(packet->normal->chunks[1].msg.rcon_cmd.command, "crashmeplx");
+	EXPECT_EQ(packet->chunks[0].kind, CHUNK_KIND_CL_STARTINFO);
+	EXPECT_EQ(packet->chunks[1].kind, CHUNK_KIND_RCON_CMD);
+	EXPECT_STREQ(packet->chunks[1].msg.rcon_cmd.command, "crashmeplx");
 
 	free(packet);
 }

--- a/test/packet_normal.cc
+++ b/test/packet_normal.cc
@@ -30,5 +30,5 @@ TEST(NormalPacket, StartInfoAndRconCmd) {
 	EXPECT_EQ(packet->chunks[1].kind, CHUNK_KIND_RCON_CMD);
 	EXPECT_STREQ(packet->chunks[1].msg.rcon_cmd->command, "crashmeplx");
 
-	free(packet);
+	free_packet(packet);
 }

--- a/test/packet_normal.cc
+++ b/test/packet_normal.cc
@@ -28,7 +28,7 @@ TEST(NormalPacket, StartInfoAndRconCmd) {
 
 	EXPECT_EQ(packet->chunks[0].kind, CHUNK_KIND_CL_STARTINFO);
 	EXPECT_EQ(packet->chunks[1].kind, CHUNK_KIND_RCON_CMD);
-	EXPECT_STREQ(packet->chunks[1].msg.rcon_cmd.command, "crashmeplx");
+	EXPECT_STREQ(packet->chunks[1].msg.rcon_cmd->command, "crashmeplx");
 
 	free(packet);
 }

--- a/test/packet_normal.cc
+++ b/test/packet_normal.cc
@@ -18,18 +18,18 @@ TEST(NormalPacket, StartInfoAndRconCmd) {
 		0x78, 0x00, 0x3d, 0xe3, 0x94, 0x8d};
 
 	Error err = Error::ERR_NONE;
-	PacketNormal *packet = (PacketNormal *)decode(bytes, sizeof(bytes), &err);
+	Packet *packet = decode(bytes, sizeof(bytes), &err);
 	EXPECT_TRUE(packet != nullptr);
 	EXPECT_EQ(err, Error::ERR_NONE);
 	EXPECT_EQ(packet->_, PacketKind::PACKET_NORMAL);
 	EXPECT_EQ(packet->header.flags, 0);
 	EXPECT_EQ(packet->header.num_chunks, 2);
 	EXPECT_EQ(packet->header.ack, 6);
-	EXPECT_EQ(packet->token, 0x3de3948d);
+	EXPECT_EQ(packet->header.token, 0x3de3948d);
 
-	EXPECT_EQ(packet->chunks[0].kind, CHUNK_KIND_CL_STARTINFO);
-	EXPECT_EQ(packet->chunks[1].kind, CHUNK_KIND_RCON_CMD);
-	EXPECT_STREQ(packet->chunks[1].msg.rcon_cmd.command, "crashmeplx");
+	EXPECT_EQ(packet->normal->chunks[0].kind, CHUNK_KIND_CL_STARTINFO);
+	EXPECT_EQ(packet->normal->chunks[1].kind, CHUNK_KIND_RCON_CMD);
+	EXPECT_STREQ(packet->normal->chunks[1].msg.rcon_cmd.command, "crashmeplx");
 
 	free(packet);
 }

--- a/test/packet_normal.cc
+++ b/test/packet_normal.cc
@@ -20,7 +20,7 @@ TEST(NormalPacket, StartInfoAndRconCmd) {
 	Packet *packet = decode(bytes, sizeof(bytes), &err);
 	EXPECT_TRUE(packet != nullptr);
 	EXPECT_EQ(err, Error::ERR_NONE);
-	EXPECT_EQ(packet->_, PacketKind::PACKET_NORMAL);
+	EXPECT_EQ(packet->kind, PacketKind::PACKET_NORMAL);
 	EXPECT_EQ(packet->header.flags, 0);
 	EXPECT_EQ(packet->header.num_chunks, 2);
 	EXPECT_EQ(packet->header.ack, 6);


### PR DESCRIPTION
Addresses https://github.com/MilkeeyCat/ddnet_protocol/issues/43#issuecomment-2525312418

Getting rid of the magic cast is nice! The rest I am not so sure about :sweat_smile: 
I do not like the name normal.

```C++
EXPECT_STREQ(packet->normal->chunks[1].msg.rcon_cmd.command, "crashmeplx");
```

Imo this line could look really smooth if it would not say "normal" in the middle.

Also I was thinking about global namespace pollution. The method ``decode`` will conflict/shadow with every function and variable the user wants to import or define. And now there is also the quite generic struct name ``Packet``. Maybe it should be called ``DDNetPacket`` and ``decode_packet``