### PR TITLE
more efficient way of working with chunks

### DIFF
--- a/docs/chunk.md
+++ b/docs/chunk.md
@@ -92,8 +92,7 @@ typedef struct {
 	ChunkKind kind;
 	ChunkHeader header;
 	union {
-		void *unused;
-		MsgRconCmd *rcon_cmd;
+		MsgRconCmd rcon_cmd;
 	} msg;
 } Chunk;
 ```

--- a/docs/packet.md
+++ b/docs/packet.md
@@ -157,7 +157,10 @@ typedef struct {
 	PacketHeader header;
 	union {
 		PacketControl *control;
-		Chunk chunks[MAX_CHUNKS];
+		struct {
+			Chunk *data;
+			size_t len;
+		} chunks;
 	};
 } Packet;
 ```
@@ -184,7 +187,7 @@ https://github.com/MilkeeyCat/ddnet_protocol/issues/54
 ## Syntax
 
 ```C
-Packet *decode(uint8_t *buf, size_t len, Error *err);
+Packet decode(uint8_t *buf, size_t len, Error *err);
 ```
 
 Given a pointer to the beginning of a udp payload

--- a/include/ddnet_protocol/chunk.h
+++ b/include/ddnet_protocol/chunk.h
@@ -67,7 +67,6 @@ typedef struct {
 	ChunkKind kind;
 	ChunkHeader header;
 	union {
-		void *unused;
-		MsgRconCmd *rcon_cmd;
+		MsgRconCmd rcon_cmd;
 	} msg;
 } Chunk;

--- a/include/ddnet_protocol/common.h
+++ b/include/ddnet_protocol/common.h
@@ -27,6 +27,7 @@ extern void *memset(void *s, int c, size_t n);
 extern void *malloc(size_t size);
 extern void free(void *ptr);
 extern char *strncpy(char *dest, const char *src, size_t len);
+extern void *memcpy(void *dest, const void *src, size_t n);
 #ifndef strlen
 extern size_t strlen(const char *str);
 #endif

--- a/include/ddnet_protocol/fetch_chunks.h
+++ b/include/ddnet_protocol/fetch_chunks.h
@@ -6,7 +6,9 @@
 #include "packet.h"
 #include "token.h"
 
+typedef void (*OnChunk)(void *ctx, Chunk *chunk);
+
 // Given a buffer containing the packet payload without packet header.
 // It will extract all system and game messages.
 // And store them in the given packet struct.
-Error fetch_chunks(uint8_t *buf, size_t len, Packet *packet);
+Error fetch_chunks(uint8_t *buf, size_t len, PacketHeader *header, OnChunk callback, void *ctx);

--- a/include/ddnet_protocol/packet.h
+++ b/include/ddnet_protocol/packet.h
@@ -114,7 +114,10 @@ typedef struct {
 	PacketHeader header;
 	union {
 		PacketControl *control;
-		Chunk chunks[MAX_CHUNKS];
+		struct {
+			Chunk *data;
+			size_t len;
+		} chunks;
 	};
 } Packet;
 
@@ -132,7 +135,7 @@ PacketHeader decode_packet_header(uint8_t *buf);
 // It returns `NULL` on error. Check the `err` value for more details.
 // Or a pointer to newly allocated memory that holds the parsed packet struct.
 // It is your responsiblity to free it using `free_packet()`
-Packet *decode(uint8_t *buf, size_t len, Error *err);
+Packet decode(uint8_t *buf, size_t len, Error *err);
 
 // Frees a packet struct and all of its fields
 Error free_packet(Packet *packet);

--- a/src/message.c
+++ b/src/message.c
@@ -20,9 +20,7 @@ static Error decode_game_message(Chunk *chunk, MessageId msg_id, Unpacker *unpac
 static Error decode_system_message(Chunk *chunk, MessageId msg_id, Unpacker *unpacker) {
 	switch(msg_id) {
 	case MSG_RCON_CMD:
-		assert(chunk->msg.rcon_cmd == NULL);
-		chunk->msg.rcon_cmd = malloc(sizeof(MsgRconCmd));
-		chunk->msg.rcon_cmd->command = unpacker_get_string(unpacker);
+		chunk->msg.rcon_cmd.command = unpacker_get_string(unpacker);
 		chunk->kind = CHUNK_KIND_RCON_CMD;
 		break;
 	default:

--- a/src/packet.c
+++ b/src/packet.c
@@ -11,32 +11,51 @@ PacketHeader decode_packet_header(uint8_t *buf) {
 	};
 }
 
-Packet *decode(uint8_t *buf, size_t len, Error *err) {
+typedef struct {
+	Chunk *chunks;
+	size_t len;
+} Context;
+
+static void on_chunk(void *ctx, Chunk *chunk) {
+	Context *context = ctx;
+
+	memcpy(&context->chunks[context->len++], chunk, sizeof(Chunk));
+}
+
+Packet decode(uint8_t *buf, size_t len, Error *err) {
+	Packet packet;
+
 	if(len < PACKET_HEADER_SIZE || len > MAX_PACKET_SIZE) {
 		if(err) {
 			*err = ERR_INVALID_PACKET;
 		}
 
-		return NULL;
+		return packet;
 	}
 
-	Packet *packet = malloc(sizeof(Packet));
-	memset(packet, 0, sizeof(*packet));
-	packet->header = decode_packet_header(buf);
+	packet.header = decode_packet_header(buf);
 
-	if(packet->header.flags & PACKET_FLAG_CONTROL) {
-		packet->kind = PACKET_CONTROL;
-		packet->control = decode_control(&buf[3], len - 3, &packet->header, err);
+	if(packet.header.flags & PACKET_FLAG_CONTROL) {
+		packet.kind = PACKET_CONTROL;
+		packet.control = decode_control(&buf[3], len - 3, &packet.header, err);
 	} else {
-		packet->kind = PACKET_NORMAL;
-		Error chunk_error = fetch_chunks(&buf[3], len - 3, packet);
+		packet.kind = PACKET_NORMAL;
+		Context ctx = {
+			.chunks = malloc(sizeof(Chunk) * packet.header.num_chunks),
+			.len = 0,
+		};
+		Error chunk_error = fetch_chunks(&buf[3], len - 3, &packet.header, on_chunk, &ctx);
+
 		if(chunk_error != ERR_NONE) {
 			if(err) {
 				*err = chunk_error;
 			}
-			free_packet(packet);
-			return NULL;
+
+			return packet;
 		}
+
+		packet.chunks.data = ctx.chunks;
+		packet.chunks.len = ctx.len;
 	}
 
 	return packet;
@@ -44,10 +63,8 @@ Packet *decode(uint8_t *buf, size_t len, Error *err) {
 
 Error free_packet(Packet *packet) {
 	if(packet->kind == PACKET_NORMAL) {
-		for(size_t i = 0; i < MAX_CHUNKS; i++) {
-			free(packet->chunks[i].msg.unused);
-		}
+		free(packet->chunks.data);
 	}
-	free(packet);
+
 	return ERR_NONE;
 }

--- a/test/packet_control.cc
+++ b/test/packet_control.cc
@@ -8,86 +8,80 @@ extern "C" {
 TEST(ControlPacket, Keepalive) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x00, 0x4e, 0xc7, 0x3b, 0x04};
 	Error err = Error::ERR_NONE;
-	Packet *packet = decode(bytes, sizeof(bytes), &err);
+	Packet packet = decode(bytes, sizeof(bytes), &err);
 
-	EXPECT_TRUE(packet != nullptr);
 	EXPECT_EQ(err, Error::ERR_NONE);
-	EXPECT_EQ(packet->kind, PacketKind::PACKET_CONTROL);
-	EXPECT_EQ(packet->header.flags, PacketFlag::PACKET_FLAG_CONTROL);
-	EXPECT_EQ(packet->header.num_chunks, 0);
-	EXPECT_EQ(packet->header.ack, 0);
-	EXPECT_EQ(packet->header.token, 0x4ec73b04);
-	EXPECT_EQ(packet->control->kind, ControlMessageKind::CTRL_MSG_KEEPALIVE);
-	EXPECT_TRUE(packet->control->reason == nullptr);
-	free_packet(packet);
+	EXPECT_EQ(packet.kind, PacketKind::PACKET_CONTROL);
+	EXPECT_EQ(packet.header.flags, PacketFlag::PACKET_FLAG_CONTROL);
+	EXPECT_EQ(packet.header.num_chunks, 0);
+	EXPECT_EQ(packet.header.ack, 0);
+	EXPECT_EQ(packet.header.token, 0x4ec73b04);
+	EXPECT_EQ(packet.control->kind, ControlMessageKind::CTRL_MSG_KEEPALIVE);
+	EXPECT_TRUE(packet.control->reason == nullptr);
+	free_packet(&packet);
 }
 
 TEST(ControlPacket, Connect) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x01, 0x54, 0x4b, 0x45, 0x4e, 0xff, 0xff, 0xff, 0xff};
 	Error err = Error::ERR_NONE;
-	Packet *packet = decode(bytes, sizeof(bytes), &err);
+	Packet packet = decode(bytes, sizeof(bytes), &err);
 
-	EXPECT_TRUE(packet != nullptr);
 	EXPECT_EQ(err, Error::ERR_NONE);
-	EXPECT_EQ(packet->kind, PacketKind::PACKET_CONTROL);
-	EXPECT_EQ(packet->control->kind, ControlMessageKind::CTRL_MSG_CONNECT);
-	EXPECT_EQ(packet->header.token, 0xffffffff);
-	EXPECT_TRUE(packet->control->reason == nullptr);
-	free_packet(packet);
+	EXPECT_EQ(packet.kind, PacketKind::PACKET_CONTROL);
+	EXPECT_EQ(packet.control->kind, ControlMessageKind::CTRL_MSG_CONNECT);
+	EXPECT_EQ(packet.header.token, 0xffffffff);
+	EXPECT_TRUE(packet.control->reason == nullptr);
+	free_packet(&packet);
 }
 
 TEST(ControlPacket, ConnectAccept) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x02, 0x54, 0x4b, 0x45, 0x4e, 0x4e, 0xc7, 0x3b, 0x04};
 	Error err = Error::ERR_NONE;
-	Packet *packet = decode(bytes, sizeof(bytes), &err);
+	Packet packet = decode(bytes, sizeof(bytes), &err);
 
-	EXPECT_TRUE(packet != nullptr);
 	EXPECT_EQ(err, Error::ERR_NONE);
-	EXPECT_EQ(packet->kind, PacketKind::PACKET_CONTROL);
-	EXPECT_EQ(packet->control->kind, ControlMessageKind::CTRL_MSG_CONNECTACCEPT);
-	EXPECT_EQ(packet->header.token, 0x4ec73b04);
-	EXPECT_TRUE(packet->control->reason == nullptr);
-	free_packet(packet);
+	EXPECT_EQ(packet.kind, PacketKind::PACKET_CONTROL);
+	EXPECT_EQ(packet.control->kind, ControlMessageKind::CTRL_MSG_CONNECTACCEPT);
+	EXPECT_EQ(packet.header.token, 0x4ec73b04);
+	EXPECT_TRUE(packet.control->reason == nullptr);
+	free_packet(&packet);
 }
 
 TEST(ControlPacket, Accept) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x03, 0x4e, 0xc7, 0x3b, 0x04};
 	Error err = Error::ERR_NONE;
-	Packet *packet = decode(bytes, sizeof(bytes), &err);
+	Packet packet = decode(bytes, sizeof(bytes), &err);
 
-	EXPECT_TRUE(packet != nullptr);
 	EXPECT_EQ(err, Error::ERR_NONE);
-	EXPECT_EQ(packet->kind, PacketKind::PACKET_CONTROL);
-	EXPECT_EQ(packet->control->kind, ControlMessageKind::CTRL_MSG_ACCEPT);
-	EXPECT_EQ(packet->header.token, 0x4ec73b04);
-	EXPECT_TRUE(packet->control->reason == nullptr);
-	free_packet(packet);
+	EXPECT_EQ(packet.kind, PacketKind::PACKET_CONTROL);
+	EXPECT_EQ(packet.control->kind, ControlMessageKind::CTRL_MSG_ACCEPT);
+	EXPECT_EQ(packet.header.token, 0x4ec73b04);
+	EXPECT_TRUE(packet.control->reason == nullptr);
+	free_packet(&packet);
 }
 
 TEST(ControlPacket, Close) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x04, 0x4e, 0xc7, 0x3b, 0x04};
 	Error err = Error::ERR_NONE;
-	Packet *packet = decode(bytes, sizeof(bytes), &err);
+	Packet packet = decode(bytes, sizeof(bytes), &err);
 
-	EXPECT_TRUE(packet != nullptr);
 	EXPECT_EQ(err, Error::ERR_NONE);
-	EXPECT_EQ(packet->kind, PacketKind::PACKET_CONTROL);
-	EXPECT_EQ(packet->control->kind, ControlMessageKind::CTRL_MSG_CLOSE);
-	EXPECT_EQ(packet->header.token, 0x4ec73b04);
-	EXPECT_TRUE(packet->control->reason == nullptr);
-	free_packet(packet);
+	EXPECT_EQ(packet.kind, PacketKind::PACKET_CONTROL);
+	EXPECT_EQ(packet.control->kind, ControlMessageKind::CTRL_MSG_CLOSE);
+	EXPECT_EQ(packet.header.token, 0x4ec73b04);
+	EXPECT_TRUE(packet.control->reason == nullptr);
+	free_packet(&packet);
 }
 
 TEST(ControlPacket, CloseWithReason) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x04, 0x74, 0x6f, 0x6f, 0x20, 0x62, 0x61, 0x64, 0x00, 0x4e, 0xc7, 0x3b, 0x04};
 	Error err = Error::ERR_NONE;
-	Packet *packet = decode(bytes, sizeof(bytes), &err);
+	Packet packet = decode(bytes, sizeof(bytes), &err);
 
-	EXPECT_TRUE(packet != nullptr);
 	EXPECT_EQ(err, Error::ERR_NONE);
-	EXPECT_EQ(packet->kind, PacketKind::PACKET_CONTROL);
-	EXPECT_EQ(packet->control->kind, ControlMessageKind::CTRL_MSG_CLOSE);
-	EXPECT_EQ(packet->header.token, 0x4ec73b04);
-	EXPECT_STREQ(packet->control->reason, "too bad");
-	free_packet(packet);
+	EXPECT_EQ(packet.kind, PacketKind::PACKET_CONTROL);
+	EXPECT_EQ(packet.control->kind, ControlMessageKind::CTRL_MSG_CLOSE);
+	EXPECT_EQ(packet.header.token, 0x4ec73b04);
+	EXPECT_STREQ(packet.control->reason, "too bad");
+	free_packet(&packet);
 }

--- a/test/packet_normal.cc
+++ b/test/packet_normal.cc
@@ -17,18 +17,18 @@ TEST(NormalPacket, StartInfoAndRconCmd) {
 		0x78, 0x00, 0x3d, 0xe3, 0x94, 0x8d};
 
 	Error err = Error::ERR_NONE;
-	Packet *packet = decode(bytes, sizeof(bytes), &err);
-	EXPECT_TRUE(packet != nullptr);
+	Packet packet = decode(bytes, sizeof(bytes), &err);
+
 	EXPECT_EQ(err, Error::ERR_NONE);
-	EXPECT_EQ(packet->kind, PacketKind::PACKET_NORMAL);
-	EXPECT_EQ(packet->header.flags, 0);
-	EXPECT_EQ(packet->header.num_chunks, 2);
-	EXPECT_EQ(packet->header.ack, 6);
-	EXPECT_EQ(packet->header.token, 0x3de3948d);
+	EXPECT_EQ(packet.kind, PacketKind::PACKET_NORMAL);
+	EXPECT_EQ(packet.header.flags, 0);
+	EXPECT_EQ(packet.header.num_chunks, 2);
+	EXPECT_EQ(packet.header.ack, 6);
+	EXPECT_EQ(packet.header.token, 0x3de3948d);
 
-	EXPECT_EQ(packet->chunks[0].kind, CHUNK_KIND_CL_STARTINFO);
-	EXPECT_EQ(packet->chunks[1].kind, CHUNK_KIND_RCON_CMD);
-	EXPECT_STREQ(packet->chunks[1].msg.rcon_cmd->command, "crashmeplx");
+	EXPECT_EQ(packet.chunks.data[0].kind, CHUNK_KIND_CL_STARTINFO);
+	EXPECT_EQ(packet.chunks.data[1].kind, CHUNK_KIND_RCON_CMD);
+	EXPECT_STREQ(packet.chunks.data[1].msg.rcon_cmd.command, "crashmeplx");
 
-	free_packet(packet);
+	free_packet(&packet);
 }


### PR DESCRIPTION
`fetch_chunks` now takes 2 more params: `callback` and `context`. If little Timmy wants to make a tool which reads bytes and parses the packet and he doesn't care about `malloc` being called he can just do this:
```C
#include <ddnet_protocol/errors.h>
#include <ddnet_protocol/fetch_chunks.h>
#include <ddnet_protocol/huffman.h>
#include <ddnet_protocol/packet.h>
#include <stdint.h>
#include <stdio.h>
#include <string.h>

void on_chunk(void *ctx, Chunk *chunk) {
  printf("Got the packet of kind %d\n", chunk->kind);
}

int main() {
  uint8_t bytes[] = {
      0x00, 0x06, 0x02, 0x42, 0x0d, 0x05, 0x28, 0x43, 0x68, 0x69, 0x6c, 0x6c,
      0x65, 0x72, 0x44, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x00, 0x7c, 0x2a, 0x4b,
      0x6f, 0x47, 0x2a, 0x7c, 0x00, 0x80, 0x01, 0x67, 0x72, 0x65, 0x65, 0x6e,
      0x73, 0x77, 0x61, 0x72, 0x64, 0x00, 0x00, 0x87, 0xc5, 0x8d, 0x0e, 0x8e,
      0xab, 0x9e, 0x02, 0x40, 0x0c, 0x06, 0x23, 0x63, 0x72, 0x61, 0x73, 0x68,
      0x6d, 0x65, 0x70, 0x6c, 0x78, 0x00, 0x3d, 0xe3, 0x94, 0x8d};

  Error err = ERR_NONE;
  Packet packet = decode(bytes, sizeof(bytes), &err);

  if (packet.kind == PACKET_NORMAL) {
    for (size_t i = 0; i < packet.chunks.len; i++) {
      printf("Got the packet of kind: %d\n", packet.chunks.data[i].kind);
    }
  } else {
    printf("Connless(not supported yet) or control packet\n");
  }
```
But if you think `malloc` is cringe, you can handle chunks yourself:
```C
#include <ddnet_protocol/errors.h>
#include <ddnet_protocol/fetch_chunks.h>
#include <ddnet_protocol/huffman.h>
#include <ddnet_protocol/packet.h>
#include <stdint.h>
#include <stdio.h>
#include <string.h>

void on_chunk(void *ctx, Chunk *chunk) {
  printf("Got the packet of kind %d\n", chunk->kind);
}

int main() {
  uint8_t bytes[] = {
      0x00, 0x06, 0x02, 0x42, 0x0d, 0x05, 0x28, 0x43, 0x68, 0x69, 0x6c, 0x6c,
      0x65, 0x72, 0x44, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x00, 0x7c, 0x2a, 0x4b,
      0x6f, 0x47, 0x2a, 0x7c, 0x00, 0x80, 0x01, 0x67, 0x72, 0x65, 0x65, 0x6e,
      0x73, 0x77, 0x61, 0x72, 0x64, 0x00, 0x00, 0x87, 0xc5, 0x8d, 0x0e, 0x8e,
      0xab, 0x9e, 0x02, 0x40, 0x0c, 0x06, 0x23, 0x63, 0x72, 0x61, 0x73, 0x68,
      0x6d, 0x65, 0x70, 0x6c, 0x78, 0x00, 0x3d, 0xe3, 0x94, 0x8d};

  uint8_t payload[2048];
  size_t len = sizeof(bytes);
  PacketHeader header = decode_packet_header(bytes);

  if (header.flags & PACKET_FLAG_COMPRESSION) {
    len = huffman_decompress(bytes + PACKET_HEADER_SIZE,
                             sizeof(bytes) - PACKET_HEADER_SIZE, payload,
                             sizeof(payload));
  } else {
    memcpy(payload, bytes, sizeof(bytes));
  }

  Error err = fetch_chunks(&payload[3], len - 3, &header, on_chunk, NULL);
}
```