### PR TITLE
feat: automatically huffman decompress

### DIFF
--- a/docs/packet.md
+++ b/docs/packet.md
@@ -47,7 +47,7 @@ not sent over the network
 
 ```C
 typedef enum {
-	// Indicating that the packet is a control packet (See the `PacketControl` struct)
+	// Indicating that the packet is a control packet (See the `ControlMessage` struct)
 	// Can not be mixed with the PACKET_FLAG_COMPRESSION!
 	PACKET_FLAG_CONTROL = 1 << 2,
 	// Inidicating that the packet is a connection less packet.
@@ -124,7 +124,7 @@ typedef enum {
 
 Type of control packet
 
-# PacketControl
+# ControlMessage
 
 ## Syntax
 
@@ -132,10 +132,10 @@ Type of control packet
 typedef struct {
 	ControlMessageKind kind;
 	char *reason; // Can be set if msg_kind == CTRL_MSG_CLOSE
-} PacketControl;
+} ControlMessage;
 ```
 
-Control packet
+Payload of control packets
 
 # MAX_CHUNKS
 
@@ -155,8 +155,10 @@ allow the user to define their own max? To reduce memory usage.
 typedef struct {
 	PacketKind kind;
 	PacketHeader header;
+	// The parsed packet payload
+	// Check `kind` to know which field in the union to access
 	union {
-		PacketControl *control;
+		ControlMessage *control;
 		struct {
 			Chunk *data;
 			size_t len;
@@ -181,6 +183,18 @@ Warning it does not set the `token` because this one is at the end of
 the payload.
 So it is the responsibility of the payload unpacker to parse the token.
 https://github.com/MilkeeyCat/ddnet_protocol/issues/54
+
+# get_packet_payload
+
+## Syntax
+
+```C
+size_t get_packet_payload(PacketHeader *header, uint8_t *full_data, size_t full_len, uint8_t *payload, size_t payload_len, Error *err);
+```
+
+Extract and decompress packet payload.
+Given a full raw packet as `full_data`
+It will extract only the payload into `payload` and return the size of the payload.
 
 # decode
 

--- a/include/ddnet_protocol/control_message.h
+++ b/include/ddnet_protocol/control_message.h
@@ -9,7 +9,7 @@ extern "C" {
 
 // Given a buffer containing the packet payload without packet header.
 // It will extract one control message.
-PacketControl *decode_control(uint8_t *buf, size_t len, PacketHeader *header, Error *err);
+ControlMessage *decode_control(uint8_t *buf, size_t len, PacketHeader *header, Error *err);
 
 #ifdef __cplusplus
 }

--- a/src/control_message.c
+++ b/src/control_message.c
@@ -1,8 +1,8 @@
 #include "packet.h"
 
-#include "packet_control.h"
+#include "control_message.h"
 
-PacketControl *decode_control(uint8_t *buf, size_t len, PacketHeader *header, Error *err) {
+ControlMessage *decode_control(uint8_t *buf, size_t len, PacketHeader *header, Error *err) {
 	ControlMessageKind kind = buf[0];
 	char *reason = NULL;
 
@@ -42,11 +42,11 @@ PacketControl *decode_control(uint8_t *buf, size_t len, PacketHeader *header, Er
 		return NULL;
 	}
 
-	PacketControl *packet = malloc(sizeof(PacketControl));
+	ControlMessage *msg = malloc(sizeof(ControlMessage));
 
 	header->token = read_token(&buf[1]);
-	packet->kind = kind;
-	packet->reason = reason;
+	msg->kind = kind;
+	msg->reason = reason;
 
-	return packet;
+	return msg;
 }

--- a/src/packet.c
+++ b/src/packet.c
@@ -1,7 +1,9 @@
 #include "packet.h"
+#include "common.h"
+#include "control_message.h"
 #include "errors.h"
 #include "fetch_chunks.h"
-#include "packet_control.h"
+#include "huffman.h"
 
 PacketHeader decode_packet_header(uint8_t *buf) {
 	return (PacketHeader){
@@ -22,8 +24,18 @@ static void on_chunk(void *ctx, Chunk *chunk) {
 	memcpy(&context->chunks[context->len++], chunk, sizeof(Chunk));
 }
 
+size_t get_packet_payload(PacketHeader *header, uint8_t *full_data, size_t full_len, uint8_t *payload, size_t payload_len, Error *err) {
+	full_data += PACKET_HEADER_SIZE;
+	full_len -= PACKET_HEADER_SIZE;
+	if(header->flags & PACKET_FLAG_COMPRESSION) {
+		return huffman_decompress(full_data, full_len, payload, payload_len, err);
+	}
+	memcpy(payload, full_data, payload_len);
+	return full_len;
+}
+
 Packet decode(uint8_t *buf, size_t len, Error *err) {
-	Packet packet;
+	Packet packet = {};
 
 	if(len < PACKET_HEADER_SIZE || len > MAX_PACKET_SIZE) {
 		if(err) {
@@ -35,17 +47,22 @@ Packet decode(uint8_t *buf, size_t len, Error *err) {
 
 	packet.header = decode_packet_header(buf);
 
+	uint8_t payload[MAX_PACKET_SIZE];
+	size_t payload_len = get_packet_payload(&packet.header, buf, len, payload, sizeof(payload), err);
+	if(*err != ERR_NONE) {
+		return packet;
+	}
+
 	if(packet.header.flags & PACKET_FLAG_CONTROL) {
 		packet.kind = PACKET_CONTROL;
-		packet.control = decode_control(&buf[3], len - 3, &packet.header, err);
+		packet.control = decode_control(payload, payload_len, &packet.header, err);
 	} else {
 		packet.kind = PACKET_NORMAL;
 		Context ctx = {
 			.chunks = malloc(sizeof(Chunk) * packet.header.num_chunks),
 			.len = 0,
 		};
-		Error chunk_error = fetch_chunks(&buf[3], len - 3, &packet.header, on_chunk, &ctx);
-
+		Error chunk_error = fetch_chunks(payload, payload_len, &packet.header, on_chunk, &ctx);
 		if(chunk_error != ERR_NONE) {
 			if(err) {
 				*err = chunk_error;

--- a/test/packet_control.cc
+++ b/test/packet_control.cc
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <ddnet_protocol/control_message.h>
 #include <ddnet_protocol/packet.h>
-#include <ddnet_protocol/packet_control.h>
 
 TEST(ControlPacket, Keepalive) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x00, 0x4e, 0xc7, 0x3b, 0x04};


### PR DESCRIPTION
~~This will probably conflict with https://github.com/MilkeeyCat/ddnet_protocol/pull/62~~ :white_check_mark: 
And it does not feel super polished yet.

But the idea is to replace the magic number 3 with PACKET_HEADER_SIZE.
And also to provide the user with a `get_packet_payload()` method which might not be needed if it is always called from `decode()`
It abstracts away the compression from the user.
And now the `Packet` struct always contains the payload and payload decompressed ready to be inspected.

Now everything could also be just taking `Packet *` as an argument and fetch all the info from it.