### PR TITLE
refactor: use extern C in public headers

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -27,3 +27,5 @@ jobs:
       run: scripts/check_types.sh
     - name: Check raw stdlib includes
       run: scripts/check_standard_headers.sh
+    - name: Check extern C annotation
+      run: scripts/check_public_headers.sh

--- a/include/ddnet_protocol/chunk.h
+++ b/include/ddnet_protocol/chunk.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "common.h"
 #include "msg_system.h"
 
@@ -70,3 +74,7 @@ typedef struct {
 		MsgRconCmd rcon_cmd;
 	} msg;
 } Chunk;
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/ddnet_protocol/common.h
+++ b/include/ddnet_protocol/common.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef BLOAT
 #include <assert.h>
 #include <stdbool.h>
@@ -38,3 +42,7 @@ extern size_t strlen(const char *str);
 #endif
 
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/ddnet_protocol/errors.h
+++ b/include/ddnet_protocol/errors.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // generic error enum
 // holds all kind of errors returned
 // by different functions
@@ -18,3 +22,7 @@ typedef enum {
 	ERR_MISSING_DDNET_SECURITY_TOKEN,
 	ERR_HUFFMAN_NODE_NULL,
 } Error;
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/ddnet_protocol/fetch_chunks.h
+++ b/include/ddnet_protocol/fetch_chunks.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "chunk.h"
 #include "common.h"
 #include "errors.h"
@@ -12,3 +16,7 @@ typedef void (*OnChunk)(void *ctx, Chunk *chunk);
 // It will extract all system and game messages.
 // And store them in the given packet struct.
 Error fetch_chunks(uint8_t *buf, size_t len, PacketHeader *header, OnChunk callback, void *ctx);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/ddnet_protocol/huffman.h
+++ b/include/ddnet_protocol/huffman.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "common.h"
 #include "errors.h"
 
@@ -18,3 +22,7 @@ size_t huffman_compress(const uint8_t *input, size_t input_len, uint8_t *output,
 //
 // See also https://chillerdragon.github.io/teeworlds-protocol/06/fundamentals.html#huffman
 size_t huffman_decompress(const uint8_t *input, size_t input_len, uint8_t *output, size_t output_len, Error *err);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/ddnet_protocol/message.h
+++ b/include/ddnet_protocol/message.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "chunk.h"
 #include "common.h"
 #include "errors.h"
@@ -23,3 +27,7 @@ typedef enum {
 //
 // this function could also be called decode_chunk_payload()
 Error decode_message(Chunk *chunk, uint8_t *buf);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/ddnet_protocol/msg_system.h
+++ b/include/ddnet_protocol/msg_system.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "common.h"
 
 // Sent by the client.
@@ -7,3 +11,7 @@
 typedef struct {
 	const char *command;
 } MsgRconCmd;
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/ddnet_protocol/packer.h
+++ b/include/ddnet_protocol/packer.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "common.h"
 #include "errors.h"
 
@@ -159,3 +163,7 @@ bool unpacker_get_bool(Unpacker *unpacker);
 // unpacker.err; // => Error::ERR_NONE
 // ```
 const uint8_t *unpacker_get_raw(Unpacker *unpacker, size_t len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/ddnet_protocol/packet.h
+++ b/include/ddnet_protocol/packet.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "chunk.h"
 #include "common.h"
 #include "errors.h"
@@ -139,3 +143,7 @@ Packet decode(uint8_t *buf, size_t len, Error *err);
 
 // Frees a packet struct and all of its fields
 Error free_packet(Packet *packet);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/ddnet_protocol/packet_control.h
+++ b/include/ddnet_protocol/packet_control.h
@@ -1,8 +1,16 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "packet.h"
 #include "token.h"
 
 // Given a buffer containing the packet payload without packet header.
 // It will extract one control message.
 PacketControl *decode_control(uint8_t *buf, size_t len, PacketHeader *header, Error *err);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/ddnet_protocol/token.h
+++ b/include/ddnet_protocol/token.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "common.h"
 
 // 4 byte security token used in packet headers
@@ -31,3 +35,7 @@ extern const Token TOKEN_MAGIC;
 //
 // the data in `buf` is expected to be in network endianness
 Token read_token(const uint8_t *buf);
+
+#ifdef __cplusplus
+}
+#endif

--- a/scripts/check_public_headers.sh
+++ b/scripts/check_public_headers.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+errors=0
+
+for header in ./include/ddnet_protocol/*.h
+do
+	if ! grep -q '^extern "C" {' "$header"
+	then
+		printf 'Error: header is missing extern C annotation %s\n' "$header" 1>&2
+		errors="$((errors+1))"
+	fi
+done
+
+if [ "$errors" != 0 ]
+then
+	printf 'Error: public header check failed with %d errors\n' "$errors" 1>&2
+	exit 1
+fi

--- a/scripts/docs.rb
+++ b/scripts/docs.rb
@@ -173,6 +173,12 @@ def parse_docs(filepath)
       comment += "\n"
       next
     end
+    if line.strip == 'extern "C" {'
+      next
+    end
+    if line.strip == '}'
+      next
+    end
 
     # if its not a comment or a filtered line
     # we assume we hit the C type that is being document

--- a/test/chunk.cc
+++ b/test/chunk.cc
@@ -1,8 +1,6 @@
 #include <gtest/gtest.h>
 
-extern "C" {
 #include <ddnet_protocol/chunk.h>
-}
 
 TEST(Chunk, HeaderVital) {
 	uint8_t bytes[] = {0x44, 0x04, 0x01, 0x00};

--- a/test/chunk_header.cc
+++ b/test/chunk_header.cc
@@ -1,8 +1,6 @@
 #include <gtest/gtest.h>
 
-extern "C" {
 #include <ddnet_protocol/chunk.h>
-}
 
 TEST(ChunkHeader, Vital) {
 	uint8_t bytes[] = {0x44, 0x04, 0x01, 0x00};

--- a/test/huffman.cc
+++ b/test/huffman.cc
@@ -1,10 +1,8 @@
 #include <gtest/gtest.h>
 
-extern "C" {
 #include <ddnet_protocol/common.h>
 #include <ddnet_protocol/errors.h>
 #include <ddnet_protocol/huffman.h>
-}
 
 TEST(Huffman, Decompress) {
 	uint8_t decompressed[512];

--- a/test/packer.cc
+++ b/test/packer.cc
@@ -1,10 +1,8 @@
 #include <cstring>
 #include <gtest/gtest.h>
 
-extern "C" {
 #include <ddnet_protocol/errors.h>
 #include <ddnet_protocol/packer.h>
-}
 
 TEST(Packer, SingleByteInts) {
 	Packer packer;

--- a/test/packet.cc
+++ b/test/packet.cc
@@ -1,8 +1,6 @@
 #include <gtest/gtest.h>
 
-extern "C" {
 #include <ddnet_protocol/packet.h>
-}
 
 TEST(Packet, Header) {
 	uint8_t bytes[] = {0x80, 0x02, 0x05};

--- a/test/packet_control.cc
+++ b/test/packet_control.cc
@@ -1,9 +1,7 @@
 #include <gtest/gtest.h>
 
-extern "C" {
 #include <ddnet_protocol/packet.h>
 #include <ddnet_protocol/packet_control.h>
-}
 
 TEST(ControlPacket, Keepalive) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x00, 0x4e, 0xc7, 0x3b, 0x04};

--- a/test/packet_header.cc
+++ b/test/packet_header.cc
@@ -1,8 +1,6 @@
 #include <gtest/gtest.h>
 
-extern "C" {
 #include <ddnet_protocol/packet.h>
-}
 
 TEST(PacketHeader, NormalNoFlags) {
 	uint8_t bytes[] = {0x00, 0x06, 0x02};

--- a/test/packet_normal.cc
+++ b/test/packet_normal.cc
@@ -1,8 +1,6 @@
 #include <gtest/gtest.h>
 
-extern "C" {
 #include <ddnet_protocol/packet.h>
-}
 
 TEST(NormalPacket, StartInfoAndRconCmd) {
 	uint8_t bytes[] = {


### PR DESCRIPTION
Closed #61

Adapted the docs script to ignore closing curly braces (hope this is not causing issues later -.-)
Removed the extern C from the tests and added it to the headers.
Add extern C requirement check to the CI