### PR TITLE
refactor: rename `decode()` to `decode_packet()`

### DIFF
--- a/docs/packet.md
+++ b/docs/packet.md
@@ -147,7 +147,7 @@ Payload of control packets
 
 allow the user to define their own max? To reduce memory usage.
 
-# Packet
+# DDNetPacket
 
 ## Syntax
 
@@ -164,7 +164,7 @@ typedef struct {
 			size_t len;
 		} chunks;
 	};
-} Packet;
+} DDNetPacket;
 ```
 
 Holds information about on full ddnet packet
@@ -201,7 +201,7 @@ It will extract only the payload into `payload` and return the size of the paylo
 ## Syntax
 
 ```C
-Packet decode_packet(uint8_t *buf, size_t len, Error *err);
+DDNetPacket decode_packet(uint8_t *buf, size_t len, Error *err);
 ```
 
 Given a pointer to the beginning of a udp payload
@@ -216,7 +216,7 @@ It is your responsiblity to free it using `free_packet()`
 ## Syntax
 
 ```C
-Error free_packet(Packet *packet);
+Error free_packet(DDNetPacket *packet);
 ```
 
 Frees a packet struct and all of its fields

--- a/docs/packet.md
+++ b/docs/packet.md
@@ -196,12 +196,12 @@ Extract and decompress packet payload.
 Given a full raw packet as `full_data`
 It will extract only the payload into `payload` and return the size of the payload.
 
-# decode
+# decode_packet
 
 ## Syntax
 
 ```C
-Packet decode(uint8_t *buf, size_t len, Error *err);
+Packet decode_packet(uint8_t *buf, size_t len, Error *err);
 ```
 
 Given a pointer to the beginning of a udp payload

--- a/include/ddnet_protocol/packet.h
+++ b/include/ddnet_protocol/packet.h
@@ -147,7 +147,7 @@ size_t get_packet_payload(PacketHeader *header, uint8_t *full_data, size_t full_
 // It returns `NULL` on error. Check the `err` value for more details.
 // Or a pointer to newly allocated memory that holds the parsed packet struct.
 // It is your responsiblity to free it using `free_packet()`
-Packet decode(uint8_t *buf, size_t len, Error *err);
+Packet decode_packet(uint8_t *buf, size_t len, Error *err);
 
 // Frees a packet struct and all of its fields
 Error free_packet(Packet *packet);

--- a/include/ddnet_protocol/packet.h
+++ b/include/ddnet_protocol/packet.h
@@ -126,7 +126,7 @@ typedef struct {
 			size_t len;
 		} chunks;
 	};
-} Packet;
+} DDNetPacket;
 
 // Unpacks packet header and fills the `PacketHeader` struct.
 //
@@ -147,10 +147,10 @@ size_t get_packet_payload(PacketHeader *header, uint8_t *full_data, size_t full_
 // It returns `NULL` on error. Check the `err` value for more details.
 // Or a pointer to newly allocated memory that holds the parsed packet struct.
 // It is your responsiblity to free it using `free_packet()`
-Packet decode_packet(uint8_t *buf, size_t len, Error *err);
+DDNetPacket decode_packet(uint8_t *buf, size_t len, Error *err);
 
 // Frees a packet struct and all of its fields
-Error free_packet(Packet *packet);
+Error free_packet(DDNetPacket *packet);
 
 #ifdef __cplusplus
 }

--- a/src/packet.c
+++ b/src/packet.c
@@ -34,7 +34,7 @@ size_t get_packet_payload(PacketHeader *header, uint8_t *full_data, size_t full_
 	return full_len;
 }
 
-Packet decode(uint8_t *buf, size_t len, Error *err) {
+Packet decode_packet(uint8_t *buf, size_t len, Error *err) {
 	Packet packet = {};
 
 	if(len < PACKET_HEADER_SIZE || len > MAX_PACKET_SIZE) {

--- a/src/packet.c
+++ b/src/packet.c
@@ -34,8 +34,8 @@ size_t get_packet_payload(PacketHeader *header, uint8_t *full_data, size_t full_
 	return full_len;
 }
 
-Packet decode_packet(uint8_t *buf, size_t len, Error *err) {
-	Packet packet = {};
+DDNetPacket decode_packet(uint8_t *buf, size_t len, Error *err) {
+	DDNetPacket packet = {};
 
 	if(len < PACKET_HEADER_SIZE || len > MAX_PACKET_SIZE) {
 		if(err) {
@@ -78,7 +78,7 @@ Packet decode_packet(uint8_t *buf, size_t len, Error *err) {
 	return packet;
 }
 
-Error free_packet(Packet *packet) {
+Error free_packet(DDNetPacket *packet) {
 	if(packet->kind == PACKET_NORMAL) {
 		free(packet->chunks.data);
 	}

--- a/test/packet.cc
+++ b/test/packet.cc
@@ -2,7 +2,7 @@
 
 #include <ddnet_protocol/packet.h>
 
-TEST(Packet, Header) {
+TEST(DDNetPacket, Header) {
 	uint8_t bytes[] = {0x80, 0x02, 0x05};
 	PacketHeader header = decode_packet_header(bytes);
 

--- a/test/packet_control.cc
+++ b/test/packet_control.cc
@@ -6,7 +6,7 @@
 TEST(ControlPacket, Keepalive) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x00, 0x4e, 0xc7, 0x3b, 0x04};
 	Error err = Error::ERR_NONE;
-	Packet packet = decode_packet(bytes, sizeof(bytes), &err);
+	DDNetPacket packet = decode_packet(bytes, sizeof(bytes), &err);
 
 	EXPECT_EQ(err, Error::ERR_NONE);
 	EXPECT_EQ(packet.kind, PacketKind::PACKET_CONTROL);
@@ -22,7 +22,7 @@ TEST(ControlPacket, Keepalive) {
 TEST(ControlPacket, Connect) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x01, 0x54, 0x4b, 0x45, 0x4e, 0xff, 0xff, 0xff, 0xff};
 	Error err = Error::ERR_NONE;
-	Packet packet = decode_packet(bytes, sizeof(bytes), &err);
+	DDNetPacket packet = decode_packet(bytes, sizeof(bytes), &err);
 
 	EXPECT_EQ(err, Error::ERR_NONE);
 	EXPECT_EQ(packet.kind, PacketKind::PACKET_CONTROL);
@@ -35,7 +35,7 @@ TEST(ControlPacket, Connect) {
 TEST(ControlPacket, ConnectAccept) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x02, 0x54, 0x4b, 0x45, 0x4e, 0x4e, 0xc7, 0x3b, 0x04};
 	Error err = Error::ERR_NONE;
-	Packet packet = decode_packet(bytes, sizeof(bytes), &err);
+	DDNetPacket packet = decode_packet(bytes, sizeof(bytes), &err);
 
 	EXPECT_EQ(err, Error::ERR_NONE);
 	EXPECT_EQ(packet.kind, PacketKind::PACKET_CONTROL);
@@ -48,7 +48,7 @@ TEST(ControlPacket, ConnectAccept) {
 TEST(ControlPacket, Accept) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x03, 0x4e, 0xc7, 0x3b, 0x04};
 	Error err = Error::ERR_NONE;
-	Packet packet = decode_packet(bytes, sizeof(bytes), &err);
+	DDNetPacket packet = decode_packet(bytes, sizeof(bytes), &err);
 
 	EXPECT_EQ(err, Error::ERR_NONE);
 	EXPECT_EQ(packet.kind, PacketKind::PACKET_CONTROL);
@@ -61,7 +61,7 @@ TEST(ControlPacket, Accept) {
 TEST(ControlPacket, Close) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x04, 0x4e, 0xc7, 0x3b, 0x04};
 	Error err = Error::ERR_NONE;
-	Packet packet = decode_packet(bytes, sizeof(bytes), &err);
+	DDNetPacket packet = decode_packet(bytes, sizeof(bytes), &err);
 
 	EXPECT_EQ(err, Error::ERR_NONE);
 	EXPECT_EQ(packet.kind, PacketKind::PACKET_CONTROL);
@@ -74,7 +74,7 @@ TEST(ControlPacket, Close) {
 TEST(ControlPacket, CloseWithReason) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x04, 0x74, 0x6f, 0x6f, 0x20, 0x62, 0x61, 0x64, 0x00, 0x4e, 0xc7, 0x3b, 0x04};
 	Error err = Error::ERR_NONE;
-	Packet packet = decode_packet(bytes, sizeof(bytes), &err);
+	DDNetPacket packet = decode_packet(bytes, sizeof(bytes), &err);
 
 	EXPECT_EQ(err, Error::ERR_NONE);
 	EXPECT_EQ(packet.kind, PacketKind::PACKET_CONTROL);

--- a/test/packet_control.cc
+++ b/test/packet_control.cc
@@ -6,7 +6,7 @@
 TEST(ControlPacket, Keepalive) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x00, 0x4e, 0xc7, 0x3b, 0x04};
 	Error err = Error::ERR_NONE;
-	Packet packet = decode(bytes, sizeof(bytes), &err);
+	Packet packet = decode_packet(bytes, sizeof(bytes), &err);
 
 	EXPECT_EQ(err, Error::ERR_NONE);
 	EXPECT_EQ(packet.kind, PacketKind::PACKET_CONTROL);
@@ -22,7 +22,7 @@ TEST(ControlPacket, Keepalive) {
 TEST(ControlPacket, Connect) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x01, 0x54, 0x4b, 0x45, 0x4e, 0xff, 0xff, 0xff, 0xff};
 	Error err = Error::ERR_NONE;
-	Packet packet = decode(bytes, sizeof(bytes), &err);
+	Packet packet = decode_packet(bytes, sizeof(bytes), &err);
 
 	EXPECT_EQ(err, Error::ERR_NONE);
 	EXPECT_EQ(packet.kind, PacketKind::PACKET_CONTROL);
@@ -35,7 +35,7 @@ TEST(ControlPacket, Connect) {
 TEST(ControlPacket, ConnectAccept) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x02, 0x54, 0x4b, 0x45, 0x4e, 0x4e, 0xc7, 0x3b, 0x04};
 	Error err = Error::ERR_NONE;
-	Packet packet = decode(bytes, sizeof(bytes), &err);
+	Packet packet = decode_packet(bytes, sizeof(bytes), &err);
 
 	EXPECT_EQ(err, Error::ERR_NONE);
 	EXPECT_EQ(packet.kind, PacketKind::PACKET_CONTROL);
@@ -48,7 +48,7 @@ TEST(ControlPacket, ConnectAccept) {
 TEST(ControlPacket, Accept) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x03, 0x4e, 0xc7, 0x3b, 0x04};
 	Error err = Error::ERR_NONE;
-	Packet packet = decode(bytes, sizeof(bytes), &err);
+	Packet packet = decode_packet(bytes, sizeof(bytes), &err);
 
 	EXPECT_EQ(err, Error::ERR_NONE);
 	EXPECT_EQ(packet.kind, PacketKind::PACKET_CONTROL);
@@ -61,7 +61,7 @@ TEST(ControlPacket, Accept) {
 TEST(ControlPacket, Close) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x04, 0x4e, 0xc7, 0x3b, 0x04};
 	Error err = Error::ERR_NONE;
-	Packet packet = decode(bytes, sizeof(bytes), &err);
+	Packet packet = decode_packet(bytes, sizeof(bytes), &err);
 
 	EXPECT_EQ(err, Error::ERR_NONE);
 	EXPECT_EQ(packet.kind, PacketKind::PACKET_CONTROL);
@@ -74,7 +74,7 @@ TEST(ControlPacket, Close) {
 TEST(ControlPacket, CloseWithReason) {
 	uint8_t bytes[] = {0x10, 0x00, 0x00, 0x04, 0x74, 0x6f, 0x6f, 0x20, 0x62, 0x61, 0x64, 0x00, 0x4e, 0xc7, 0x3b, 0x04};
 	Error err = Error::ERR_NONE;
-	Packet packet = decode(bytes, sizeof(bytes), &err);
+	Packet packet = decode_packet(bytes, sizeof(bytes), &err);
 
 	EXPECT_EQ(err, Error::ERR_NONE);
 	EXPECT_EQ(packet.kind, PacketKind::PACKET_CONTROL);

--- a/test/packet_normal.cc
+++ b/test/packet_normal.cc
@@ -15,7 +15,7 @@ TEST(NormalPacket, StartInfoAndRconCmd) {
 		0x78, 0x00, 0x3d, 0xe3, 0x94, 0x8d};
 
 	Error err = Error::ERR_NONE;
-	Packet packet = decode_packet(bytes, sizeof(bytes), &err);
+	DDNetPacket packet = decode_packet(bytes, sizeof(bytes), &err);
 
 	EXPECT_EQ(err, Error::ERR_NONE);
 	EXPECT_EQ(packet.kind, PacketKind::PACKET_NORMAL);

--- a/test/packet_normal.cc
+++ b/test/packet_normal.cc
@@ -15,7 +15,7 @@ TEST(NormalPacket, StartInfoAndRconCmd) {
 		0x78, 0x00, 0x3d, 0xe3, 0x94, 0x8d};
 
 	Error err = Error::ERR_NONE;
-	Packet packet = decode(bytes, sizeof(bytes), &err);
+	Packet packet = decode_packet(bytes, sizeof(bytes), &err);
 
 	EXPECT_EQ(err, Error::ERR_NONE);
 	EXPECT_EQ(packet.kind, PacketKind::PACKET_NORMAL);


### PR DESCRIPTION
The keyword `decode` is too generic for the public namespace.