### PR TITLE
feat: chunk header encoding and flags refactor

### DIFF
--- a/docs/chunk.md
+++ b/docs/chunk.md
@@ -18,10 +18,10 @@ typedef enum {
 	// Vital chunks are reliable.
 	// They contain a sequence number and will be resend
 	// if the peer did not acknowledge that sequence number.
-	CHUNK_FLAG_VITAL = 1,
+	CHUNK_FLAG_VITAL = 0b01000000,
 	// If this exact message was already sent the resend flag is set.
 	// This can happen if there is lag or packet loss.
-	CHUNK_FLAG_RESEND,
+	CHUNK_FLAG_RESEND = 0b10000000,
 } ChunkFlag;
 ```
 
@@ -66,6 +66,29 @@ ChunkHeader decode_chunk_header(uint8_t **buf_ptr);
 Given a pointer to a byte buffer it will parse it as a chunk header.
 The pointer is then incremented by 2 or 3 depending on how many bytes
 where consumed.
+
+# encode_chunk_header
+
+## Syntax
+
+```C
+uint8_t *encode_chunk_header(const ChunkHeader *header, uint8_t *buf);
+```
+
+Given a filled header struct it it will pack it into `buf`
+writing either 2 or 3 bytes depending on the header type.
+
+It then returns a pointer to the last byte written.
+Example usage:
+
+```C
+ChunkHeader header = {
+	.flags = CHUNK_FLAG_VITAL,
+	.size = 2,
+	.sequence = 4};
+uint8_t buf[8];
+uint8_t *buf_writer = encode_chunk_header(&header, buf);
+```
 
 # ChunkKind
 

--- a/include/ddnet_protocol/chunk.h
+++ b/include/ddnet_protocol/chunk.h
@@ -20,11 +20,11 @@ typedef enum {
 	// Vital chunks are reliable.
 	// They contain a sequence number and will be resend
 	// if the peer did not acknowledge that sequence number.
-	CHUNK_FLAG_VITAL = 1,
+	CHUNK_FLAG_VITAL = 0b01000000,
 
 	// If this exact message was already sent the resend flag is set.
 	// This can happen if there is lag or packet loss.
-	CHUNK_FLAG_RESEND,
+	CHUNK_FLAG_RESEND = 0b10000000,
 } ChunkFlag;
 
 // Every game or system message is packed in a chunk.
@@ -50,6 +50,22 @@ typedef struct {
 // The pointer is then incremented by 2 or 3 depending on how many bytes
 // where consumed.
 ChunkHeader decode_chunk_header(uint8_t **buf_ptr);
+
+// Given a filled header struct it it will pack it into `buf`
+// writing either 2 or 3 bytes depending on the header type.
+//
+// It then returns a pointer to the last byte written.
+// Example usage:
+//
+// ```C
+// ChunkHeader header = {
+// 	.flags = CHUNK_FLAG_VITAL,
+// 	.size = 2,
+// 	.sequence = 4};
+// uint8_t buf[8];
+// uint8_t *buf_writer = encode_chunk_header(&header, buf);
+// ```
+uint8_t *encode_chunk_header(const ChunkHeader *header, uint8_t *buf);
 
 // Holds the type of `msg` in a `Chunk` struct
 //

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -4,8 +4,8 @@ ChunkHeader decode_chunk_header(uint8_t **buf_ptr) {
 	ChunkHeader header;
 	uint8_t *buf = *buf_ptr;
 
-	header.flags = (buf[0] >> 6) & 3;
-	header.size = ((buf[0] & 0x3f) << 4) | (buf[1] & ((1 << 4) - 1));
+	header.flags = buf[0] & 0b11000000;
+	header.size = ((buf[0] & 0b00111111) << 4) | (buf[1] & ((1 << 4) - 1));
 	header.sequence = 0;
 
 	if(header.flags & CHUNK_FLAG_VITAL) {
@@ -17,4 +17,15 @@ ChunkHeader decode_chunk_header(uint8_t **buf_ptr) {
 	}
 
 	return header;
+}
+
+uint8_t *encode_chunk_header(const ChunkHeader *header, uint8_t *buf) {
+	buf[0] = header->flags & 0b11000000 | ((header->size >> 4) & 0b00111111);
+	buf[1] = (header->size & 0b00001111);
+	if(header->flags & CHUNK_FLAG_VITAL) {
+		buf[1] |= (header->sequence >> 2) & 0b11110000;
+		buf[2] = header->sequence & 0xff;
+		return buf + 3;
+	}
+	return buf + 2;
 }

--- a/test/chunk.cc
+++ b/test/chunk.cc
@@ -1,3 +1,6 @@
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
 #include <gtest/gtest.h>
 
 #include <ddnet_protocol/chunk.h>
@@ -7,9 +10,9 @@ TEST(Chunk, HeaderVital) {
 	uint8_t *buf = &bytes[0];
 	ChunkHeader header = decode_chunk_header(&buf);
 
-	EXPECT_EQ(header.flags, 0x01);
-	EXPECT_EQ(header.size, 0x44);
-	EXPECT_EQ(header.sequence, 0x01);
+	EXPECT_EQ(header.flags, CHUNK_FLAG_VITAL);
+	EXPECT_EQ(header.size, 68);
+	EXPECT_EQ(header.sequence, 1);
 	EXPECT_EQ(&bytes[sizeof(bytes) - 1], buf);
 }
 
@@ -19,7 +22,32 @@ TEST(Chunk, HeaderNotVital) {
 	ChunkHeader header = decode_chunk_header(&buf);
 
 	EXPECT_EQ(header.flags, 0x00);
-	EXPECT_EQ(header.size, 0x21);
-	EXPECT_EQ(header.sequence, 0x00);
+	EXPECT_EQ(header.size, 33);
+	EXPECT_EQ(header.sequence, 0);
 	EXPECT_EQ(&bytes[sizeof(bytes) - 1], buf);
+}
+
+TEST(Chunk, PackNonVitalHeader) {
+	ChunkHeader header = {
+		.flags = 0,
+		.size = 2};
+	uint8_t output[8];
+	uint8_t *end = encode_chunk_header(&header, output);
+	uint8_t expected[] = {0x00, 0x02};
+	EXPECT_TRUE(std::memcmp(output, expected, sizeof(expected)) == 0);
+	size_t bytes_written = end - output;
+	EXPECT_EQ(bytes_written, 2);
+}
+
+TEST(Chunk, PackVitalHeader) {
+	ChunkHeader header = {
+		.flags = CHUNK_FLAG_VITAL,
+		.size = 2,
+		.sequence = 4};
+	uint8_t output[8];
+	uint8_t *end = encode_chunk_header(&header, output);
+	uint8_t expected[] = {0x40, 0x02, 0x04};
+	EXPECT_TRUE(std::memcmp(output, expected, sizeof(expected)) == 0);
+	size_t bytes_written = end - output;
+	EXPECT_EQ(bytes_written, 3);
 }

--- a/test/chunk_header.cc
+++ b/test/chunk_header.cc
@@ -7,7 +7,7 @@ TEST(ChunkHeader, Vital) {
 	uint8_t *buf = &bytes[0];
 	ChunkHeader header = decode_chunk_header(&buf);
 
-	EXPECT_EQ(header.flags, 0x01);
+	EXPECT_EQ(header.flags, CHUNK_FLAG_VITAL);
 	EXPECT_EQ(header.size, 0x44);
 	EXPECT_EQ(header.sequence, 0x01);
 	EXPECT_EQ(&bytes[sizeof(bytes) - 1], buf);
@@ -18,7 +18,7 @@ TEST(ChunkHeader, NotVital) {
 	uint8_t *buf = &bytes[0];
 	ChunkHeader header = decode_chunk_header(&buf);
 
-	EXPECT_EQ(header.flags, 0x01);
+	EXPECT_EQ(header.flags, CHUNK_FLAG_VITAL);
 	EXPECT_EQ(header.size, 0x44);
 	EXPECT_EQ(header.sequence, 0x01);
 	EXPECT_EQ(&bytes[sizeof(bytes) - 1], buf);


### PR DESCRIPTION
Keeping the chunk flags vital and resend closer to the network protocol. This removes the need for shifting the flags around and makes setting them by hand smoother.

Replaced some hex with decimal values in the test because they represent numbers not raw data.