### PR TITLE
chore: install clang-format 20 & remove `Language` option

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,4 @@
 ---
-Language: Cpp
 AccessModifierOffset: -8
 AlignAfterOpenBracket: DontAlign
 AlignEscapedNewlines: DontAlign

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -18,14 +18,11 @@ jobs:
       run: |
         sudo apt-get update -y
         sudo apt-get install -y pkg-config cmake cmake build-essential shellcheck
-        wget https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-46b8640/clang-format-10_linux-amd64
-        echo "b8ed0cfc9cded28f8c0c9dd0da402d1287453b7d55a68bf243b432035aebcaa4720bfff22440d1f1c5d4c82f7b8d85948214cca85a2aa976589b88459e440521 clang-format-10_linux-amd64" | sha512sum -c
+        wget https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-2da3e7b/clang-format-20_linux-amd64
+        echo "aa033826df57bd965486c291f2218531ecd38ed815e42dc186a938af564600cb26bc911c091faeb63d2ba981e3b85beddce36ad5d1837ffe83c7a417c13fd69e  clang-format-20_linux-amd64" | sha512sum -c
         mkdir -p ~/.local/bin
-        mv clang-format-10_linux-amd64 ~/.local/bin/clang-format
+        mv clang-format-20_linux-amd64 ~/.local/bin/clang-format
         chmod +x ~/.local/bin/clang-format
-    - name: Check clang format version
-      run: |
-        clang-format -version # expect 10
     - name: Check fix_style
       run: scripts/fix_style.sh --dry-run
     - name: Check raw C types


### PR DESCRIPTION
Since we have C and C++ code it doesn't make sense to have `Language: Cpp`

Also, previously C files were formatted incorrectly but after I removed `Language` option it works fine for C and C++ files