### PR TITLE
packing normal packets is a pain because of having to know the chunk size

### DIFF
--- a/docs/chunk.md
+++ b/docs/chunk.md
@@ -137,3 +137,16 @@ exactly one net message of either type game or system.
 To access the net message struct check the `kind`
 and access the `msg` union accordingly.
 
+# fill_chunk_header
+
+## Syntax
+
+```C
+Error fill_chunk_header(Chunk *chunk);
+```
+
+Given an entire chunk that has all values
+for message in the payload already set
+This function will fill the chunks header accordingly
+For now this only means setting the correct size based on the payload
+

--- a/include/ddnet_protocol/chunk.h
+++ b/include/ddnet_protocol/chunk.h
@@ -5,6 +5,7 @@ extern "C" {
 #endif
 
 #include "common.h"
+#include "errors.h"
 #include "msg_game.h"
 #include "msg_system.h"
 
@@ -100,6 +101,12 @@ typedef struct {
 		MsgClStartInfo start_info;
 	} msg;
 } Chunk;
+
+// Given an entire chunk that has all values
+// for message in the payload already set
+// This function will fill the chunks header accordingly
+// For now this only means setting the correct size based on the payload
+Error fill_chunk_header(Chunk *chunk);
 
 #ifdef __cplusplus
 }

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -1,4 +1,7 @@
 #include "chunk.h"
+#include "errors.h"
+#include "message.h"
+#include "packet.h"
 
 size_t decode_chunk_header(const uint8_t *buf, ChunkHeader *header) {
 	header->flags = buf[0] & 0b11000000;
@@ -25,4 +28,15 @@ size_t encode_chunk_header(const ChunkHeader *header, uint8_t *buf) {
 	}
 
 	return 2;
+}
+
+Error fill_chunk_header(Chunk *chunk) {
+	uint8_t chunk_payload[MAX_PACKET_SIZE];
+	Error encode_err = ERR_NONE;
+	size_t chunk_payload_len = encode_message(chunk, chunk_payload, &encode_err);
+	if(encode_err != ERR_NONE) {
+		return encode_err;
+	}
+	chunk->header.size = chunk_payload_len;
+	return ERR_NONE;
 }


### PR DESCRIPTION
This is more an issue than an pr for now. Until it is out of draft at least.
The problem is when a user tries to pack a message they have to also fill in the chunk headers size. Which is all packed fields plus the packed message id and system flag. That is something the user should really not bother with. The piece of code that knows it best should set it. And that would be the packing code.

I would propose a magic size value of -1 or something like that. If that is passed to encode_packet it will calculate the needed size and overwrite it. If the user passes something other than -1 it will use that size even if it is wrong to allow sending any kind of garbage packet if someone wants to.

I did the same in twnet_parser.