### PR TITLE
refactor: prefix public huffman symbols with ddnet_

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ int main() {
 	uint8_t decompressed[512];
 	uint8_t compressed[] = {0x74, 0xde, 0x16, 0xd9, 0xa2, 0x8a, 0x1b};
 	Error err = ERR_NONE;
-	huffman_decompress(compressed, sizeof(compressed), decompressed, sizeof(decompressed), &err);
+	ddnet_huffman_decompress(compressed, sizeof(compressed), decompressed, sizeof(decompressed), &err);
 	if(err == ERR_NONE) {
 		puts((const char *)decompressed); // foo
 	}

--- a/docs/huffman.md
+++ b/docs/huffman.md
@@ -1,9 +1,9 @@
-# huffman_compress
+# ddnet_huffman_compress
 
 ## Syntax
 
 ```C
-size_t huffman_compress(const uint8_t *input, size_t input_len, uint8_t *output, size_t output_len, Error *err);
+size_t ddnet_huffman_compress(const uint8_t *input, size_t input_len, uint8_t *output, size_t output_len, Error *err);
 ```
 
 applies huffman compression to the given `input`
@@ -13,12 +13,12 @@ returns the size of the compressed `output`
 
 See also https://chillerdragon.github.io/teeworlds-protocol/06/fundamentals.html#huffman
 
-# huffman_decompress
+# ddnet_huffman_decompress
 
 ## Syntax
 
 ```C
-size_t huffman_decompress(const uint8_t *input, size_t input_len, uint8_t *output, size_t output_len, Error *err);
+size_t ddnet_huffman_decompress(const uint8_t *input, size_t input_len, uint8_t *output, size_t output_len, Error *err);
 ```
 
 applies huffman decompression to the given `input`

--- a/examples/huffman.c
+++ b/examples/huffman.c
@@ -7,7 +7,7 @@ int main() {
 	uint8_t decompressed[512];
 	uint8_t compressed[] = {0x74, 0xde, 0x16, 0xd9, 0xa2, 0x8a, 0x1b};
 	Error err = ERR_NONE;
-	huffman_decompress(compressed, sizeof(compressed), decompressed, sizeof(decompressed), &err);
+	ddnet_huffman_decompress(compressed, sizeof(compressed), decompressed, sizeof(decompressed), &err);
 	if(err == ERR_NONE) {
 		puts((const char *)decompressed); // foo
 	}

--- a/include/ddnet_protocol/huffman.h
+++ b/include/ddnet_protocol/huffman.h
@@ -13,7 +13,7 @@ extern "C" {
 // returns the size of the compressed `output`
 //
 // See also https://chillerdragon.github.io/teeworlds-protocol/06/fundamentals.html#huffman
-size_t huffman_compress(const uint8_t *input, size_t input_len, uint8_t *output, size_t output_len, Error *err);
+size_t ddnet_huffman_compress(const uint8_t *input, size_t input_len, uint8_t *output, size_t output_len, Error *err);
 
 // applies huffman decompression to the given `input`
 // and stores the result in `output`
@@ -21,7 +21,7 @@ size_t huffman_compress(const uint8_t *input, size_t input_len, uint8_t *output,
 // returns the size of the decompressed `output`
 //
 // See also https://chillerdragon.github.io/teeworlds-protocol/06/fundamentals.html#huffman
-size_t huffman_decompress(const uint8_t *input, size_t input_len, uint8_t *output, size_t output_len, Error *err);
+size_t ddnet_huffman_decompress(const uint8_t *input, size_t input_len, uint8_t *output, size_t output_len, Error *err);
 
 #ifdef __cplusplus
 }

--- a/src/huffman.c
+++ b/src/huffman.c
@@ -168,7 +168,7 @@ static void huffman_init(void) {
 	}
 }
 
-size_t huffman_compress(const uint8_t *input, size_t input_len, uint8_t *output, size_t output_len, Error *err) {
+size_t ddnet_huffman_compress(const uint8_t *input, size_t input_len, uint8_t *output, size_t output_len, Error *err) {
 	huffman_init();
 	// this macro loads a symbol for a byte into bits and bitcount
 #define HUFFMAN_MACRO_LOADSYMBOL(sym) \
@@ -233,7 +233,7 @@ size_t huffman_compress(const uint8_t *input, size_t input_len, uint8_t *output,
 #undef HUFFMAN_MACRO_WRITE
 }
 
-size_t huffman_decompress(const uint8_t *input, size_t input_len, uint8_t *output, size_t output_len, Error *err) {
+size_t ddnet_huffman_decompress(const uint8_t *input, size_t input_len, uint8_t *output, size_t output_len, Error *err) {
 	huffman_init();
 	// setup buffer pointers
 	uint8_t *dst = output;

--- a/src/packet.c
+++ b/src/packet.c
@@ -40,7 +40,7 @@ size_t get_packet_payload(PacketHeader *header, const uint8_t *full_data, size_t
 	full_data += PACKET_HEADER_SIZE;
 	full_len -= PACKET_HEADER_SIZE;
 	if(header->flags & PACKET_FLAG_COMPRESSION) {
-		return huffman_decompress(full_data, full_len, payload, payload_len, err);
+		return ddnet_huffman_decompress(full_data, full_len, payload, payload_len, err);
 	}
 	memcpy(payload, full_data, full_len);
 	return full_len;

--- a/test/huffman.cc
+++ b/test/huffman.cc
@@ -8,7 +8,7 @@ TEST(Huffman, Decompress) {
 	uint8_t decompressed[512];
 	uint8_t compressed[] = {0x74, 0xde, 0x16, 0xd9, 0xa2, 0x8a, 0x1b};
 	Error err = ERR_NONE;
-	size_t len = huffman_decompress(compressed, sizeof(compressed), decompressed, sizeof(decompressed), &err);
+	size_t len = ddnet_huffman_decompress(compressed, sizeof(compressed), decompressed, sizeof(decompressed), &err);
 	EXPECT_EQ(err, ERR_NONE);
 	EXPECT_EQ(len, 4);
 	EXPECT_STREQ((const char *)decompressed, "foo");


### PR DESCRIPTION
To avoid naming collisions with user code