### PR TITLE
feat: add some game messages

### DIFF
--- a/docs/chunk.md
+++ b/docs/chunk.md
@@ -100,7 +100,6 @@ typedef enum {
 	DDNET_MSG_KIND_MAP_CHANGE,
 	DDNET_MSG_KIND_MAP_DATA,
 	DDNET_MSG_KIND_CON_READY,
-	DDNET_MSG_KIND_CL_STARTINFO,
 	DDNET_MSG_KIND_SNAP,
 	DDNET_MSG_KIND_SNAPEMPTY,
 	DDNET_MSG_KIND_SNAPSINGLE,
@@ -118,6 +117,10 @@ typedef enum {
 	DDNET_MSG_KIND_PING_REPLY,
 	DDNET_MSG_KIND_RCON_CMD_ADD,
 	DDNET_MSG_KIND_RCON_CMD_REM,
+	DDNET_MSG_KIND_SV_MOTD,
+	DDNET_MSG_KIND_SV_BROADCAST,
+	DDNET_MSG_KIND_SV_CHAT,
+	DDNET_MSG_KIND_CL_STARTINFO,
 } DDNetMessageKind;
 ```
 
@@ -130,7 +133,11 @@ that is sent over the network!
 
 ```C
 typedef union {
+	// ddnet_protocol specific message to represent
+	// a unknown message
+	// this message kind does not exist in the reference implementation
 	DDNetMsgUnknown unknown;
+	// system messages
 	DDNetMsgInfo info;
 	DDNetMsgMapChange map_change;
 	DDNetMsgMapData map_data;
@@ -143,6 +150,10 @@ typedef union {
 	DDNetMsgRequestMapData request_map_data;
 	DDNetMsgRconCmdAdd rcon_cmd_add;
 	DDNetMsgRconCmdRem rcon_cmd_rem;
+	// game messages
+	DDNetMsgSvMotd motd;
+	DDNetMsgSvBroadcast broadcast;
+	DDNetMsgSvChat chat;
 	DDNetMsgClStartInfo start_info;
 } DDNetGenericMessage;
 ```

--- a/docs/msg_game.md
+++ b/docs/msg_game.md
@@ -1,64 +1,83 @@
-#pragma once
+# DDNetChatTeam
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+## Syntax
 
-#include "common.h"
-
-// possible values of the team field in the chat
-// message sent by the server
+```C
 typedef enum {
 	// chat message sent to public chat
 	DDNET_CHAT_PUBLIC,
-
 	// chat message sent to team chat
 	// this can be scoped to TEAM_RED, TEAM_BLUE and TEAM_SPECTATORS
 	// beased on which team the sender is in
 	// but it can also be scoped to ddrace teams
 	DDNET_CHAT_TEAM,
-
 	// this value is a ddnet extension
 	// this is sent from the server to the client
 	// to display an outgoing ddnet whisper message
 	// in this case the client_id field on the DDNetMsgSvChat struct
 	// is the recipient not the sender. Because the sender knows his own name.
 	DDNET_CHAT_WHISPER_SEND,
-
 	// this value is a ddnet extension
 	// this is sent from the server to the client
 	// to display received whisper messages differently in the chat.
 	DDNET_CHAT_WHISPER_RECEIVE,
 } DDNetChatTeam;
+```
 
-// message of the day
-// sent by the server
-// and displayed in the middle of the screen
-// with transparent background on the client side
+possible values of the team field in the chat
+message sent by the server
+
+# DDNetMsgSvMotd
+
+## Syntax
+
+```C
 typedef struct {
 	const char *message;
 } DDNetMsgSvMotd;
+```
 
-// sent by the server
-// and displayed in the middle of the screen as white text
+message of the day
+sent by the server
+and displayed in the middle of the screen
+with transparent background on the client side
+
+# DDNetMsgSvBroadcast
+
+## Syntax
+
+```C
 typedef struct {
 	const char *message;
 } DDNetMsgSvBroadcast;
+```
 
-// sent by the server
+sent by the server
+and displayed in the middle of the screen as white text
+
+# DDNetMsgSvChat
+
+## Syntax
+
+```C
 typedef struct {
 	DDNetChatTeam team;
-
 	// client id of the message author
 	// can be -1 if the message was sent by the server
 	// can be the message recipient if the team is DDNET_CHAT_WHISPER_SEND
 	int32_t client_id;
-
 	// chat message
 	const char *message;
 } DDNetMsgSvChat;
+```
 
-// sent by the client
+sent by the server
+
+# DDNetMsgClStartInfo
+
+## Syntax
+
+```C
 typedef struct {
 	const char *name;
 	const char *clan;
@@ -68,7 +87,7 @@ typedef struct {
 	size_t color_body;
 	size_t color_feet;
 } DDNetMsgClStartInfo;
+```
 
-#ifdef __cplusplus
-}
-#endif
+sent by the client
+

--- a/include/ddnet_protocol/chunk.h
+++ b/include/ddnet_protocol/chunk.h
@@ -76,7 +76,6 @@ typedef enum {
 	DDNET_MSG_KIND_MAP_CHANGE,
 	DDNET_MSG_KIND_MAP_DATA,
 	DDNET_MSG_KIND_CON_READY,
-	DDNET_MSG_KIND_CL_STARTINFO,
 	DDNET_MSG_KIND_SNAP,
 	DDNET_MSG_KIND_SNAPEMPTY,
 	DDNET_MSG_KIND_SNAPSINGLE,
@@ -94,12 +93,21 @@ typedef enum {
 	DDNET_MSG_KIND_PING_REPLY,
 	DDNET_MSG_KIND_RCON_CMD_ADD,
 	DDNET_MSG_KIND_RCON_CMD_REM,
+	DDNET_MSG_KIND_SV_MOTD,
+	DDNET_MSG_KIND_SV_BROADCAST,
+	DDNET_MSG_KIND_SV_CHAT,
+	DDNET_MSG_KIND_CL_STARTINFO,
 } DDNetMessageKind;
 
 // Union abstracting away any kind of game or system message
 // Check the DDNetMessageKind to know which one to use
 typedef union {
+	// ddnet_protocol specific message to represent
+	// a unknown message
+	// this message kind does not exist in the reference implementation
 	DDNetMsgUnknown unknown;
+
+	// system messages
 	DDNetMsgInfo info;
 	DDNetMsgMapChange map_change;
 	DDNetMsgMapData map_data;
@@ -112,6 +120,11 @@ typedef union {
 	DDNetMsgRequestMapData request_map_data;
 	DDNetMsgRconCmdAdd rcon_cmd_add;
 	DDNetMsgRconCmdRem rcon_cmd_rem;
+
+	// game messages
+	DDNetMsgSvMotd motd;
+	DDNetMsgSvBroadcast broadcast;
+	DDNetMsgSvChat chat;
 	DDNetMsgClStartInfo start_info;
 } DDNetGenericMessage;
 

--- a/include/ddnet_protocol/message.h
+++ b/include/ddnet_protocol/message.h
@@ -42,6 +42,9 @@ typedef enum {
 	DDNET_MSG_RCON_CMD_REM = 26,
 
 	// game messages
+	DDNET_MSG_SV_MOTD = 1,
+	DDNET_MSG_SV_BROADCAST = 2,
+	DDNET_MSG_SV_CHAT = 3,
 	DDNET_MSG_CL_STARTINFO = 20,
 } DDNetMessageId;
 

--- a/scripts/docs.rb
+++ b/scripts/docs.rb
@@ -259,7 +259,7 @@ def main
     end
   end
 
-  %w(packer huffman errors token packet chunk session).each do |component|
+  %w(packer huffman errors token packet chunk session msg_game).each do |component|
     header_to_markdown(
       "include/ddnet_protocol/#{component}.h",
       "docs/#{component}.md",

--- a/src/message.c
+++ b/src/message.c
@@ -7,6 +7,20 @@
 static DDNetError decode_game_message(DDNetChunk *chunk, DDNetMessageId msg_id, DDNetUnpacker *unpacker) {
 	DDNetGenericMessage *msg = &chunk->payload.msg;
 	switch(msg_id) {
+	case DDNET_MSG_SV_MOTD:
+		chunk->payload.kind = DDNET_MSG_KIND_SV_MOTD;
+		msg->motd.message = ddnet_unpacker_get_string(unpacker);
+		break;
+	case DDNET_MSG_SV_BROADCAST:
+		chunk->payload.kind = DDNET_MSG_KIND_SV_BROADCAST;
+		msg->broadcast.message = ddnet_unpacker_get_string(unpacker);
+		break;
+	case DDNET_MSG_SV_CHAT:
+		chunk->payload.kind = DDNET_MSG_KIND_SV_CHAT;
+		msg->chat.team = ddnet_unpacker_get_int(unpacker);
+		msg->chat.client_id = ddnet_unpacker_get_int(unpacker);
+		msg->chat.message = ddnet_unpacker_get_string(unpacker);
+		break;
 	case DDNET_MSG_CL_STARTINFO:
 		chunk->payload.kind = DDNET_MSG_KIND_CL_STARTINFO;
 		msg->start_info.name = ddnet_unpacker_get_string(unpacker);
@@ -169,15 +183,6 @@ size_t ddnet_encode_message(DDNetChunk *chunk, uint8_t *buf, DDNetError *err) {
 	case DDNET_MSG_KIND_READY:
 	case DDNET_MSG_KIND_ENTERGAME:
 		break;
-	case DDNET_MSG_KIND_CL_STARTINFO:
-		ddnet_packer_add_string(&packer, msg->start_info.name);
-		ddnet_packer_add_string(&packer, msg->start_info.clan);
-		ddnet_packer_add_int(&packer, (int32_t)msg->start_info.country);
-		ddnet_packer_add_string(&packer, msg->start_info.skin);
-		ddnet_packer_add_int(&packer, msg->start_info.use_custom_color);
-		ddnet_packer_add_int(&packer, (int32_t)msg->start_info.color_body);
-		ddnet_packer_add_int(&packer, (int32_t)msg->start_info.color_feet);
-		break;
 	case DDNET_MSG_KIND_INPUTTIMING:
 		ddnet_packer_add_int(&packer, msg->input_timing.intended_tick);
 		ddnet_packer_add_int(&packer, msg->input_timing.time_left);
@@ -222,6 +227,26 @@ size_t ddnet_encode_message(DDNetChunk *chunk, uint8_t *buf, DDNetError *err) {
 		break;
 	case DDNET_MSG_KIND_RCON_CMD_REM:
 		ddnet_packer_add_string(&packer, msg->rcon_cmd_rem.name);
+		break;
+	case DDNET_MSG_KIND_SV_MOTD:
+		ddnet_packer_add_string(&packer, msg->motd.message);
+		break;
+	case DDNET_MSG_KIND_SV_BROADCAST:
+		ddnet_packer_add_string(&packer, msg->broadcast.message);
+		break;
+	case DDNET_MSG_KIND_SV_CHAT:
+		ddnet_packer_add_int(&packer, msg->chat.team);
+		ddnet_packer_add_int(&packer, msg->chat.client_id);
+		ddnet_packer_add_string(&packer, msg->chat.message);
+		break;
+	case DDNET_MSG_KIND_CL_STARTINFO:
+		ddnet_packer_add_string(&packer, msg->start_info.name);
+		ddnet_packer_add_string(&packer, msg->start_info.clan);
+		ddnet_packer_add_int(&packer, (int32_t)msg->start_info.country);
+		ddnet_packer_add_string(&packer, msg->start_info.skin);
+		ddnet_packer_add_int(&packer, msg->start_info.use_custom_color);
+		ddnet_packer_add_int(&packer, (int32_t)msg->start_info.color_body);
+		ddnet_packer_add_int(&packer, (int32_t)msg->start_info.color_feet);
 		break;
 	case DDNET_MSG_KIND_SNAP:
 	case DDNET_MSG_KIND_SNAPEMPTY:

--- a/src/packer.c
+++ b/src/packer.c
@@ -84,10 +84,6 @@ void ddnet_packer_init_msg(DDNetPacker *packer, DDNetMessageKind kind) {
 		msg_id = DDNET_MSG_CON_READY;
 		msg_category = DDNET_SYSTEM;
 		break;
-	case DDNET_MSG_KIND_CL_STARTINFO:
-		msg_id = DDNET_MSG_CL_STARTINFO;
-		msg_category = DDNET_GAME;
-		break;
 	case DDNET_MSG_KIND_SNAP:
 		msg_id = DDNET_MSG_SNAP;
 		msg_category = DDNET_SYSTEM;
@@ -155,6 +151,22 @@ void ddnet_packer_init_msg(DDNetPacker *packer, DDNetMessageKind kind) {
 	case DDNET_MSG_KIND_RCON_CMD_REM:
 		msg_id = DDNET_MSG_RCON_CMD_REM;
 		msg_category = DDNET_SYSTEM;
+		break;
+	case DDNET_MSG_KIND_SV_MOTD:
+		msg_id = DDNET_MSG_SV_MOTD;
+		msg_category = DDNET_GAME;
+		break;
+	case DDNET_MSG_KIND_SV_BROADCAST:
+		msg_id = DDNET_MSG_SV_BROADCAST;
+		msg_category = DDNET_GAME;
+		break;
+	case DDNET_MSG_KIND_SV_CHAT:
+		msg_id = DDNET_MSG_SV_CHAT;
+		msg_category = DDNET_GAME;
+		break;
+	case DDNET_MSG_KIND_CL_STARTINFO:
+		msg_id = DDNET_MSG_CL_STARTINFO;
+		msg_category = DDNET_GAME;
 		break;
 	}
 


### PR DESCRIPTION
It might be non obvious for the average pleb that the chat message sent by the server is referred to as ``chat`` and the message sent by the client is referred to as ``say``. So I added the ``sv_`` prefix to make it obvious. It does break consistency so I am not too sure about it.