### PR TITLE
chore: stricter docs regex

### DIFF
--- a/scripts/docs.rb
+++ b/scripts/docs.rb
@@ -40,7 +40,7 @@ class BaseDoc
   end
 
   def self.is_func?(line)
-    !line.match(/(const )?(u?int(32|8)_t|size_t|bool|void|char|Error|Unpacker|Token|Packet|PacketHeader|PacketKind|ChunkHeader) \*?\w+\(/).nil?
+    !line.match(/^(const )?(u?int(32|8)_t|size_t|bool|void|char|DDNetError|DDNetUnpacker|Token|DDNetPacket|PacketHeader|DDNetPacketKind|DDNetChunkHeader) \*?\w+\(/).nil?
   end
 
   def self.is_typedef?(line)


### PR DESCRIPTION
The docs.rb script did not care about all the refactorings because it matched ``DDNetError fill_chunk_header(DDNetChunk *chunk);`` just fine by just looking at ``Error`` ignoring what garbage was in front xd.