### PR TITLE
feat: add seq in backroom helper

### DIFF
--- a/docs/session.md
+++ b/docs/session.md
@@ -44,3 +44,22 @@ This struct is meant to be passed as mutable pointer to encode and decode method
 Where its sequence numbers can be read and written to based on the amount of
 vital messages packed and unpacked.
 
+# ddnet_seq_in_backroom
+
+## Syntax
+
+```C
+bool ddnet_seq_in_backroom(uint16_t sequence, uint16_t ack);
+```
+
+Only used for chunks where the sequence number does not match the expected value
+to decide wether to drop known chunks silently or request resend if something got lost
+The expected value would be the ``(last_ack + 1) % DDNET_MAX_SEQUENCE``
+
+The argument `sequence` is the sequence number of the incoming chunk
+
+The argument `ack` is the expected sequence number
+
+true - if the sequence number is already known and the chunk should be dropped
+false - if the sequence number is off and we need to request a resend of lost chunks
+

--- a/include/ddnet_protocol/session.h
+++ b/include/ddnet_protocol/session.h
@@ -49,6 +49,18 @@ typedef struct {
 	DDNetToken token;
 } DDNetSession;
 
+// Only used for chunks where the sequence number does not match the expected value
+// to decide wether to drop known chunks silently or request resend if something got lost
+// The expected value would be the ``(last_ack + 1) % DDNET_MAX_SEQUENCE``
+//
+// The argument `sequence` is the sequence number of the incoming chunk
+//
+// The argument `ack` is the expected sequence number
+//
+// true - if the sequence number is already known and the chunk should be dropped
+// false - if the sequence number is off and we need to request a resend of lost chunks
+bool ddnet_seq_in_backroom(uint16_t sequence, uint16_t ack);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/session.c
+++ b/src/session.c
@@ -1,0 +1,17 @@
+#include "session.h"
+#include "packet.h"
+
+bool ddnet_seq_in_backroom(uint16_t sequence, uint16_t ack) {
+	int32_t bottom = ack - (DDNET_MAX_SEQUENCE / 2);
+	if(bottom < 0) {
+		if(sequence <= ack) {
+			return true;
+		}
+		if(sequence >= (bottom + DDNET_MAX_SEQUENCE)) {
+			return true;
+		}
+	} else if(sequence <= ack && sequence >= bottom) {
+		return true;
+	}
+	return false;
+}


### PR DESCRIPTION
Might be borderline out of scope of the repo. It is not a parser. It is just session handling. Still think it fits here. Most people using the lib will need that.

Call site in the reference implementation:

https://github.com/ddnet/ddnet/blob/6f9c3ecfdeef405b0d7adc1c1ee76c91d9694b00/src/engine/shared/network.cpp#L72-L95

Implementation in the reference implementation:

https://github.com/ddnet/ddnet/blob/6f9c3ecfdeef405b0d7adc1c1ee76c91d9694b00/src/engine/shared/network.cpp#L422-L439

Mixing the abbreviation ack with the fully written sequence is odd. But consistent with the current code.