### PR TITLE
ci: update `actions/checkout` from `v4` to `v6`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           cmake-init-env: CXXFLAGS=/WX LDFLAGS=/WX
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -47,11 +47,11 @@ jobs:
         mkdir debug
         cd debug
         ${{ matrix.cmake-path }}cmake -E env ${{ matrix.cmake-init-env }} ${{ matrix.cmake-path }}cmake ${{ matrix.cmake-args }} -DCMAKE_BUILD_TYPE=Debug -Werror=dev ..
-        ${{ matrix.cmake-path }}cmake --build . --config Debug ${{ matrix.build-args }}
+        ${{ matrix.cmake-path }}cmake --build . --config Debug
 
     - name: Build in release mode
       run: |
         mkdir release
         cd release
         ${{ matrix.cmake-path }}cmake -E env ${{ matrix.cmake-init-env }} ${{ matrix.cmake-path }}cmake ${{ matrix.cmake-args }} -DCMAKE_BUILD_TYPE=Release -Werror=dev ..
-        ${{ matrix.cmake-path }}cmake --build . --config Release ${{ matrix.build-args }}
+        ${{ matrix.cmake-path }}cmake --build . --config Release

--- a/.github/workflows/clang-sanitizer.yml
+++ b/.github/workflows/clang-sanitizer.yml
@@ -10,7 +10,7 @@ jobs:
   check-clang-san:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Clang tidy
 
 on:
   push:
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,7 +13,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build static files using Doxygen
         run: |

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -9,5 +9,5 @@ jobs:
     name: Spell check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: crate-ci/typos@v1.35.5

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
     - name: Prepare

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           cmake-init-env: CXXFLAGS=-Werror
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -47,14 +47,14 @@ jobs:
         mkdir debug
         cd debug
         ${{ matrix.cmake-path }}cmake -E env ${{ matrix.cmake-init-env }} ${{ matrix.cmake-path }}cmake ${{ matrix.cmake-args }} -DCMAKE_BUILD_TYPE=Debug -Werror=dev ..
-        ${{ matrix.cmake-path }}cmake --build . --config Debug --target run_tests ${{ matrix.build-args }}
+        ${{ matrix.cmake-path }}cmake --build . --config Debug --target run_tests
 
     - name: Test in release mode
       run: |
         mkdir release
         cd release
         ${{ matrix.cmake-path }}cmake -E env ${{ matrix.cmake-init-env }} ${{ matrix.cmake-path }}cmake ${{ matrix.cmake-args }} -DCMAKE_BUILD_TYPE=Release -Werror=dev ..
-        ${{ matrix.cmake-path }}cmake --build . --config Release --target run_tests ${{ matrix.build-args }}
+        ${{ matrix.cmake-path }}cmake --build . --config Release --target run_tests
 
     - name: Run tests with valgrind
       if: contains(matrix.os, 'ubuntu')


### PR DESCRIPTION
Rename `clang-sanitizer.yml` workflow.
Remove `${{ matrix.build-args }}`.

Initially I wanted to fix this CMake warning https://github.com/MilkeeyCat/ddnet_protocol/actions/runs/25595589616/job/75140862663#step:5:30 buuut I ended up with these changes.

UPD. https://stackoverflow.com/a/24470998, well... it's fine as is.