### PR TITLE
refactor: rename snapshot to snapshot delta

### DIFF
--- a/include/ddnet_protocol/msg_system.h
+++ b/include/ddnet_protocol/msg_system.h
@@ -42,7 +42,7 @@ typedef struct {
 	int32_t delta_tick;
 	int32_t crc;
 	int32_t part_size;
-	DDProtoSnapshot snapshot;
+	DDProtoSnapshotDelta snapshot;
 } DDProtoMsgSnapSingle;
 
 // sent by the client

--- a/include/ddnet_protocol/snapshot.h
+++ b/include/ddnet_protocol/snapshot.h
@@ -115,14 +115,14 @@ typedef struct {
 		// `sizeof(DDProtoSnapItem)` otherwise you might run into segfaults
 		size_t len;
 	} items;
-} DDProtoSnapshot;
+} DDProtoSnapshotDelta;
 
 /// Consumes data from the unpacker and writes the parsed item to the output
 /// parameter `item`.
 DDProtoError ddproto_decode_snap_item(DDProtoUnpacker *unpacker, DDProtoSnapItem *item);
 
 /// Frees the memory allocated for the snap items.
-void ddproto_free_snapshot(DDProtoSnapshot *snap);
+void ddproto_free_snapshot_delta(DDProtoSnapshotDelta *snap);
 
 /// Given a unpacker holding data beginning with a snapshot payload this parses
 /// the snapshot header and item deltas. Beginning of snapshot payload is
@@ -136,7 +136,7 @@ void ddproto_free_snapshot(DDProtoSnapshot *snap);
 /// This function allocates memory for the snap items. You need to free it by
 /// calling @ref ddproto_free_snapshot. You do not need to free it if the
 /// snapshot is part of a packet and you already call @ref ddproto_free_packet.
-DDProtoError ddproto_decode_snapshot(DDProtoUnpacker *unpacker, DDProtoSnapshot *snap);
+DDProtoError ddproto_decode_snapshot_delta(DDProtoUnpacker *unpacker, DDProtoSnapshotDelta *snap);
 
 #ifdef __cplusplus
 }

--- a/src/message.c
+++ b/src/message.c
@@ -156,7 +156,7 @@ static DDProtoError decode_system_message(DDProtoChunk *chunk, DDProtoMessageId 
 		msg->snap_single.delta_tick = ddproto_unpacker_get_int(unpacker);
 		msg->snap_single.crc = ddproto_unpacker_get_int(unpacker);
 		msg->snap_single.part_size = ddproto_unpacker_get_int(unpacker);
-		DDProtoError err = ddproto_decode_snapshot(unpacker, &msg->snap_single.snapshot);
+		DDProtoError err = ddproto_decode_snapshot_delta(unpacker, &msg->snap_single.snapshot);
 		if(err != DDPROTO_ERR_NONE) {
 			return err;
 		}

--- a/src/packet.c
+++ b/src/packet.c
@@ -186,8 +186,8 @@ DDProtoError ddproto_free_packet(DDProtoPacket *packet) {
 		for(size_t i = 0; i < packet->chunks.len; i++) {
 			DDProtoChunk *chunk = &packet->chunks.data[i];
 			if(chunk->payload.kind == DDPROTO_MSG_KIND_SNAPSINGLE) {
-				DDProtoSnapshot *snap = &chunk->payload.msg.snap_single.snapshot;
-				ddproto_free_snapshot(snap);
+				DDProtoSnapshotDelta *snap = &chunk->payload.msg.snap_single.snapshot;
+				ddproto_free_snapshot_delta(snap);
 			}
 		}
 		free(packet->chunks.data);

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -199,7 +199,7 @@ DDProtoError ddproto_decode_snap_item(DDProtoUnpacker *unpacker, DDProtoSnapItem
 	return DDPROTO_ERR_NONE;
 }
 
-void ddproto_free_snapshot(DDProtoSnapshot *snap) {
+void ddproto_free_snapshot_delta(DDProtoSnapshotDelta *snap) {
 	free(snap->items.data);
 	free(snap->removed_keys.data);
 	snap->items.data = NULL;
@@ -208,7 +208,7 @@ void ddproto_free_snapshot(DDProtoSnapshot *snap) {
 	snap->removed_keys.len = 0;
 }
 
-DDProtoError ddproto_decode_snapshot(DDProtoUnpacker *unpacker, DDProtoSnapshot *snap) {
+DDProtoError ddproto_decode_snapshot_delta(DDProtoUnpacker *unpacker, DDProtoSnapshotDelta *snap) {
 	snap->removed_keys.len = ddproto_unpacker_get_int(unpacker);
 	if(!snap->removed_keys.len) {
 		snap->removed_keys.data = NULL;

--- a/test/snap_removed_keys.cc
+++ b/test/snap_removed_keys.cc
@@ -45,7 +45,7 @@ TEST(SnapSinglePacket, DeltaWithRemovedKeys) {
 	EXPECT_EQ(snap_single.crc, 217322961);
 	EXPECT_EQ(snap_single.part_size, 65);
 
-	DDProtoSnapshot snap = snap_single.snapshot;
+	DDProtoSnapshotDelta snap = snap_single.snapshot;
 	EXPECT_EQ(snap.removed_keys.len, 3);
 	ASSERT_NE(snap.removed_keys.data, nullptr);
 	EXPECT_EQ(snap.removed_keys.data[0], 2147090437);

--- a/test/snap_single.cc
+++ b/test/snap_single.cc
@@ -82,7 +82,7 @@ TEST(SnapSinglePacket, FirstFullSnap) {
 	EXPECT_EQ(snap_single.crc, -1521333639);
 	EXPECT_EQ(snap_single.part_size, 322);
 
-	DDProtoSnapshot snap = snap_single.snapshot;
+	DDProtoSnapshotDelta snap = snap_single.snapshot;
 	EXPECT_EQ(snap.removed_keys.len, 0);
 	EXPECT_EQ(snap.removed_keys.data, nullptr);
 

--- a/test/snap_single_flags_and_pickups.cc
+++ b/test/snap_single_flags_and_pickups.cc
@@ -96,7 +96,7 @@ TEST(SnapSinglePacket, SnapWithFlagsAndPickups) {
 	EXPECT_EQ(snap_single.crc, 1466432907);
 	EXPECT_EQ(snap_single.part_size, 522);
 
-	DDProtoSnapshot snap = snap_single.snapshot;
+	DDProtoSnapshotDelta snap = snap_single.snapshot;
 	EXPECT_EQ(snap.removed_keys.len, 0);
 	EXPECT_EQ(snap.removed_keys.data, nullptr);
 


### PR DESCRIPTION
This is a preparation for a snap builder and a new snapshot struct that holds the undiffed snapshot.

I never really touched the server side of the protocol. Usually ended up rage quitting after implementing a basic client. So not too sure about how to structure things yet but I think this will be good.

So what is sent over the network by the server is [a snapshot delta](https://chillerdragon.github.io/teeworlds-protocol/07/snap_deltas.html). Meaning it contains the identifiers of snap items from a previous snapshot that should be removed. Followed by items [that contain a diff to the previous snapshots values as payload](https://chillerdragon.github.io/teeworlds-protocol/07/snap_items.html#delta_item_example). Items not contained as diff or removed should just be kept from the previous snapshot.

The current master branch represent this using the following struct

```C
typedef struct {
	struct {
		int32_t *data;
		size_t len;
	} removed_keys;
	struct {
		// should be either `NULL` or point to memory of size
		// `items.len * sizeof(DDProtoSnapItem)`
		DDProtoSnapItem *data;

		// should be either `0` or match the allocated size of `items.data` in
		// `sizeof(DDProtoSnapItem)` otherwise you might run into segfaults
		size_t len;
	} items;
} DDProtoSnapshot;
```

But the name is a bit misleading. Because this is not a full regular snapshot. A regular final unpacked/undiffed/undeltaed snapshot does not contain removed items. And the items stored in this struct have "wrong" values. Like if someone got damaged and the health dropped down from 10 to 9. The snap item will not contain the value 9 but -1 because its one less than before.

I would like to introduce a new type called `DDProtoSnapshot` which is not a delta. Contains no diff or removed items. Just a full snapshot with absolute values. Two of these can then be used to create a delta.

That new snapshot will probably look quite similar just missing the removed keys which could also be ignored but I think using a different type makes it more clear what is going on.

```C
typedef struct {
	struct {
		// should be either `NULL` or point to memory of size
		// `items.len * sizeof(DDProtoSnapItem)`
		DDProtoSnapItem *data;

		// should be either `0` or match the allocated size of `items.data` in
		// `sizeof(DDProtoSnapItem)` otherwise you might run into segfaults
		size_t len;
	} items;
} DDProtoSnapshot;
```