### PR TITLE
feat: integrate `ddnet_corpus`

### DIFF
--- a/.github/workflows/clang-sanitizer.yml
+++ b/.github/workflows/clang-sanitizer.yml
@@ -18,6 +18,7 @@ jobs:
       run: |
         sudo apt-get update -y
         sudo apt-get install -y pkg-config cmake cmake build-essential clang
+        cargo install cbindgen
 
     - name: Build with ASan and UBSan
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,12 +34,14 @@ jobs:
       run: |
         sudo apt-get update -y
         sudo apt-get install -y pkg-config cmake cmake build-essential valgrind
+        cargo install cbindgen
 
     - name: Prepare macOS
       if: contains(matrix.os, 'macOS')
       run: |
         brew update || true
         brew install pkg-config cmake || true
+        cargo install cbindgen
         sudo rm -rf /Library/Developer/CommandLineTools
 
     - name: Test in debug mode

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "corpus"]
+	path = corpus
+	url = https://github.com/ddnet-corpus/corpus

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,12 +29,18 @@ if(CMAKE_TESTING_ENABLED)
     FILE(GLOB TEST_SOURCES test/*.cc)
     add_executable(${TARGET_TESTRUNNER} EXCLUDE_FROM_ALL ${TEST_SOURCES})
 
-    target_link_libraries(${TARGET_TESTRUNNER}
-        ddnet_protocol
-    )
-
     include(FetchContent)
-        FetchContent_Declare(
+
+    FetchContent_Declare(
+        corpus_runner_source
+        GIT_REPOSITORY "https://github.com/ddnet-corpus/runner"
+        SOURCE_DIR "corpus_runner"
+    )
+    FetchContent_MakeAvailable(corpus_runner_source)
+
+    add_subdirectory("${CMAKE_BINARY_DIR}/corpus_runner/cxx")
+
+    FetchContent_Declare(
         googletest
         URL https://github.com/google/googletest/archive/3d73dee972d0db344bda9b659836612aba6a3564.zip
     )
@@ -46,6 +52,8 @@ if(CMAKE_TESTING_ENABLED)
     target_link_libraries(
         ${TARGET_TESTRUNNER}
         GTest::gtest_main
+        ddnet_protocol
+        corpus_runner
     )
 
     include(GoogleTest)

--- a/test/corpus.cc
+++ b/test/corpus.cc
@@ -1,0 +1,38 @@
+#include <ddnet_protocol/errors.h>
+#include <ddnet_protocol/huffman.h>
+
+#include <ddcorpus/runner.hpp>
+
+#include <gtest/gtest.h>
+
+TEST(Corpus, Huffman) {
+	Corpus corpus("../corpus");
+
+	corpus.add_runner("protocol/huffman/compress", [](const uint8_t *input, uintptr_t size, const char *ext, struct DDCorpBuffer *buf) {
+		ASSERT_STREQ(ext, "bin");
+
+		uint8_t output[512];
+		DDProtoError err = DDPROTO_ERR_NONE;
+		size_t compressed_size = ddproto_huffman_compress(input, size, output, sizeof(output), &err);
+
+		ASSERT_EQ(err, DDPROTO_ERR_NONE);
+
+		ddcorp_buffer_copy(buf, output, compressed_size);
+	});
+
+	corpus.add_runner("protocol/huffman/decompress", [](const uint8_t *input, uintptr_t size, const char *ext, struct DDCorpBuffer *buf) {
+		ASSERT_STREQ(ext, "bin");
+
+		uint8_t output[512];
+		DDProtoError err = DDPROTO_ERR_NONE;
+		size_t compressed_size = ddproto_huffman_decompress(input, size, output, sizeof(output), &err);
+
+		if(err != DDPROTO_ERR_NONE) {
+			ddcorp_buffer_write_str(buf, "-1");
+		} else {
+			ddcorp_buffer_copy(buf, output, compressed_size);
+		}
+	});
+
+	ASSERT_TRUE(corpus.run());
+}


### PR DESCRIPTION
My motivation for introducing something like this is to have 1 central place for tests that can be written in a language agnostic way. I think it's great if let's say a python library could use the same test cases as our library. @ChillerDragon  I'd like to hear your opinion on this.

(tests are expected to fail because `no_trailing_null` test is yoinked from Robyt's PR)